### PR TITLE
style: apply Linear-inspired flat design to nori-web UI

### DIFF
--- a/.changeset/linear-flat-web-ui.md
+++ b/.changeset/linear-flat-web-ui.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/nori-code": patch
+---
+
+Refresh the bundled web UI with a flatter, Linear-inspired visual style: subtler borders, smaller radii, and reduced shadows across navigation, forms, chat, and dialogs.

--- a/.changeset/linear-flat-web-ui.md
+++ b/.changeset/linear-flat-web-ui.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/nori-code": patch
 ---
 
-Refresh the bundled web UI with a flatter, Linear-inspired visual style: subtler borders, smaller radii, and reduced shadows across navigation, forms, chat, and dialogs.
+Refresh the bundled web UI with a flatter, Linear-inspired visual style: neutral dark surfaces, subtle indigo edge highlights, and restrained purple gradients on shell chrome, navigation, and panels.

--- a/apps/nori-web/src/main.tsx
+++ b/apps/nori-web/src/main.tsx
@@ -7,6 +7,7 @@ import { InspectorPopout } from './components/InspectorPopout';
 import type { InspectorTab } from './components/WorkspaceInspector';
 import { ExitPlanModeMockPage } from './components/dev/ExitPlanModeMockPage';
 import './styles/nori-theme.css';
+import './styles/linear-flat.css';
 
 initializeTheme();
 const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,33 +5,37 @@
    ========================================================================== */
 
 :root {
-  /* Chrome accent — Linear lavender-indigo (#5e6ad2) */
-  --nori-cyan: #5e6ad2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.14);
-  --nori-thinking: #8b8b8b;
-  --nori-accent: #5e6ad2;
-  --nori-accent-dim: rgba(94, 106, 210, 0.14);
-  --nori-accent-edge: rgba(94, 106, 210, 0.38);
-  --nori-accent-soft: rgba(94, 106, 210, 0.07);
-  --nori-accent-hover: #6f7ae0;
-  --nori-accent-focus: #5e69d1;
+  /* Reference: Cursor / deep-violet UI — bright lavender accent on purple-tinted surfaces */
+  --nori-accent: #8b7cf8;
+  --nori-accent-bright: #a78bfa;
+  --nori-accent-focus: #9f8cff;
+  --nori-accent-hover: #9d8df9;
+  --nori-cyan: #8b7cf8;
+  --nori-cyan-dim: rgba(139, 124, 248, 0.16);
+  --nori-thinking: #9b8ec8;
+  --nori-accent-dim: rgba(139, 124, 248, 0.16);
+  --nori-accent-edge: rgba(167, 139, 250, 0.42);
+  --nori-accent-soft: rgba(139, 124, 248, 0.1);
+  --nori-accent-glow: rgba(139, 124, 248, 0.22);
+  --nori-rim-top: rgba(167, 139, 250, 0.24);
+  --nori-rim-side: rgba(167, 139, 250, 0.1);
   --nori-shell-gradient:
-    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(94, 106, 210, 0.08), transparent 52%),
-    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(130, 143, 255, 0.05), transparent 48%);
+    radial-gradient(ellipse 130% 85% at 0% -5%, rgba(139, 124, 248, 0.14), transparent 54%),
+    radial-gradient(ellipse 95% 75% at 100% 105%, rgba(167, 139, 250, 0.1), transparent 50%);
 
-  /* Neutral dark palette — purple only via gradients above */
-  --nori-bg: #090909;
-  --nori-surface: #0f0f0f;
-  --nori-surface-raised: #141414;
-  --nori-surface-hover: #1a1a1a;
-  --nori-bg-elevated: #141414;
-  --nori-border: #262626;
-  --nori-border-strong: #333333;
-  --nori-border-active: #525252;
-  --nori-text: #ededed;
-  --nori-text-secondary: #8b8b8b;
-  --nori-text-muted: #5c5c5c;
-  --nori-text-subtle: #454545;
+  /* Purple-tinted dark surfaces (not neutral gray) */
+  --nori-bg: #0c0c10;
+  --nori-surface: #12121a;
+  --nori-surface-raised: #16161f;
+  --nori-surface-hover: #1c1c28;
+  --nori-bg-elevated: #16161f;
+  --nori-border: #2a2a38;
+  --nori-border-strong: #36364a;
+  --nori-border-active: #4a4a62;
+  --nori-text: #f0f0f5;
+  --nori-text-secondary: #9b9bb0;
+  --nori-text-muted: #6b6b82;
+  --nori-text-subtle: #52526a;
 
   /* Primary action — Linear uses light buttons on dark bg */
   --nori-primary-bg: #e8e8e8;
@@ -48,13 +52,13 @@
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
 
   /* Shell tokens */
-  --nori-shell: #090909;
-  --nori-sidebar-bg: #090909;
-  --nori-topbar: #090909;
-  --nori-statusbar: #0f0f0f;
-  --nori-control: #141414;
-  --nori-control-hover: #1a1a1a;
-  --nori-control-active: #222222;
+  --nori-shell: #0c0c10;
+  --nori-sidebar-bg: #0c0c10;
+  --nori-topbar: #0c0c10;
+  --nori-statusbar: #101018;
+  --nori-control: #16161f;
+  --nori-control-hover: #1c1c28;
+  --nori-control-active: #242432;
 
   /* Spacing scale */
   --nori-space-1: 4px;
@@ -804,13 +808,6 @@ textarea.input:focus {
 }
 
 .initial-usage {
-  border-color: color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border-strong));
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 32%),
-    color-mix(in srgb, var(--nori-surface-raised) 86%, transparent);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 10%, transparent),
-    0 14px 38px rgba(0, 0, 0, 0.2);
   backdrop-filter: none;
 }
 
@@ -857,6 +854,117 @@ textarea.input:focus {
 }
 
 .cron-job-icon {
-  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
-  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
+  color: var(--nori-accent-bright);
+  background: color-mix(in srgb, var(--nori-accent) 14%, var(--nori-control));
+}
+
+/* ── Reference match: high-specificity shell overrides ───────────────────── */
+/* nori-theme.css ships later .codex-layout rules — these must win. */
+
+.codex-layout .chat-welcome .welcome-mark,
+.chat-welcome .welcome-mark {
+  color: var(--nori-accent-bright);
+  border: 1px solid color-mix(in srgb, var(--nori-accent-bright) 42%, var(--nori-border));
+  background:
+    linear-gradient(145deg, rgba(139, 124, 248, 0.24), rgba(139, 124, 248, 0.06)),
+    var(--nori-control);
+  box-shadow:
+    0 0 36px var(--nori-accent-glow),
+    inset 0 1px 0 var(--nori-rim-top);
+}
+
+.starter-card svg {
+  color: var(--nori-accent-bright);
+}
+
+.starter-card {
+  border-color: color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border));
+  background: linear-gradient(180deg, rgba(139, 124, 248, 0.04), transparent 40%), var(--nori-surface);
+  box-shadow: inset 0 1px 0 var(--nori-rim-top);
+}
+
+.codex-layout .sidebar-nav-item.active,
+.codex-layout .sidebar-tab.active,
+.codex-layout .sidebar-item.active {
+  color: var(--nori-text);
+  background: rgba(139, 124, 248, 0.14);
+  box-shadow:
+    inset 0 0 0 1px rgba(167, 139, 250, 0.28),
+    inset 0 1px 0 rgba(167, 139, 250, 0.12);
+}
+
+.codex-layout .sidebar-workspace-switch .sidebar-tab.active {
+  background: rgba(139, 124, 248, 0.16);
+  border-color: rgba(167, 139, 250, 0.32);
+  box-shadow: inset 0 1px 0 var(--nori-rim-top);
+}
+
+.codex-layout .chat-input-area {
+  border: 1px solid color-mix(in srgb, var(--nori-accent) 22%, var(--nori-border-strong));
+  background: linear-gradient(180deg, rgba(139, 124, 248, 0.05), transparent 36%), var(--nori-control);
+  box-shadow:
+    inset 0 1px 0 var(--nori-rim-top),
+    0 14px 38px rgba(0, 0, 0, 0.22);
+  backdrop-filter: none;
+}
+
+.codex-layout .chat-input-area:focus-within {
+  border-color: color-mix(in srgb, var(--nori-accent-bright) 58%, var(--nori-border-strong));
+  box-shadow:
+    inset 0 1px 0 var(--nori-rim-top),
+    0 0 0 1px rgba(139, 124, 248, 0.2),
+    0 0 32px var(--nori-accent-glow),
+    0 16px 42px rgba(0, 0, 0, 0.24);
+}
+
+.initial-usage {
+  border: 1px solid color-mix(in srgb, var(--nori-accent-bright) 34%, var(--nori-border-strong));
+  background:
+    linear-gradient(180deg, rgba(139, 124, 248, 0.1), transparent 38%),
+    color-mix(in srgb, var(--nori-surface-raised) 92%, transparent);
+  box-shadow:
+    inset 0 1px 0 var(--nori-rim-top),
+    0 0 40px rgba(139, 124, 248, 0.1),
+    0 14px 38px rgba(0, 0, 0, 0.22);
+}
+
+.initial-usage-metrics > div {
+  border-color: color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
+  background: linear-gradient(180deg, rgba(139, 124, 248, 0.04), transparent), var(--nori-control);
+  box-shadow: inset 0 1px 0 rgba(167, 139, 250, 0.08);
+}
+
+.inspector-stage.open {
+  border-color: color-mix(in srgb, var(--nori-accent-bright) 28%, var(--nori-border));
+  box-shadow:
+    inset 0 1px 0 var(--nori-rim-top),
+    0 0 36px rgba(139, 124, 248, 0.08);
+}
+
+.inspector-navigation.compact {
+  border-color: color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border));
+  box-shadow:
+    inset 0 1px 0 var(--nori-rim-top),
+    0 0 28px rgba(139, 124, 248, 0.1);
+}
+
+.inspector-navigation.compact button.active {
+  color: var(--nori-accent-bright);
+  background: rgba(139, 124, 248, 0.2);
+  box-shadow:
+    inset 0 0 0 1px rgba(167, 139, 250, 0.36),
+    0 0 18px rgba(139, 124, 248, 0.14);
+}
+
+.codex-layout .inspector-open-tab.active {
+  color: var(--nori-text);
+  box-shadow: inset 0 -2px var(--nori-accent-bright);
+}
+
+.inspector-open-tab.active {
+  box-shadow: inset 0 -2px var(--nori-accent-bright);
+}
+
+.inspector-content {
+  background: var(--nori-bg);
 }

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,19 +5,29 @@
    ========================================================================== */
 
 :root {
-  /* Linear-like neutral palette */
-  --nori-bg: #09090b;
-  --nori-surface: #111113;
-  --nori-surface-raised: #18181b;
-  --nori-surface-hover: #1f1f23;
-  --nori-bg-elevated: #18181b;
-  --nori-border: #27272a;
-  --nori-border-strong: #3f3f46;
+  /* Linear accent — indigo, used sparingly for links & focus */
+  --nori-cyan: #5E6AD2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
+  --nori-thinking: #8b8d98;
+
+  /* Linear cool dark palette */
+  --nori-bg: #0a0a0b;
+  --nori-surface: #101012;
+  --nori-surface-raised: #16161a;
+  --nori-surface-hover: #1c1c21;
+  --nori-bg-elevated: #16161a;
+  --nori-border: #2c2c30;
+  --nori-border-strong: #3a3a40;
   --nori-border-active: #52525b;
-  --nori-text: #fafafa;
-  --nori-text-secondary: #a1a1aa;
-  --nori-text-muted: #71717a;
-  --nori-text-subtle: #52525b;
+  --nori-text: #f0f0f3;
+  --nori-text-secondary: #8b8d98;
+  --nori-text-muted: #5c5c65;
+  --nori-text-subtle: #45454d;
+
+  /* Primary action — Linear uses light buttons on dark bg */
+  --nori-primary-bg: #e8e8ed;
+  --nori-primary-fg: #0a0a0b;
+  --nori-primary-hover: #f4f4f6;
 
   /* Shape — smaller, consistent radii */
   --nori-radius: 6px;
@@ -29,12 +39,12 @@
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
 
   /* Shell tokens */
-  --nori-shell: #09090b;
-  --nori-topbar: #09090b;
-  --nori-statusbar: #111113;
-  --nori-control: #18181b;
-  --nori-control-hover: #1f1f23;
-  --nori-control-active: #27272a;
+  --nori-shell: #0a0a0b;
+  --nori-topbar: #0a0a0b;
+  --nori-statusbar: #101012;
+  --nori-control: #16161a;
+  --nori-control-hover: #1c1c21;
+  --nori-control-active: #242429;
 
   /* Spacing scale */
   --nori-space-1: 4px;
@@ -48,27 +58,32 @@
 }
 
 [data-theme="light"] {
-  --nori-bg: #fafafa;
+  --nori-cyan: #4f57c7;
+  --nori-cyan-dim: rgba(79, 87, 199, 0.14);
+  --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
-  --nori-surface-raised: #f4f4f5;
-  --nori-surface-hover: #f4f4f5;
+  --nori-surface-raised: #f4f4f6;
+  --nori-surface-hover: #ececf0;
   --nori-bg-elevated: #ffffff;
-  --nori-border: #e4e4e7;
-  --nori-border-strong: #d4d4d8;
-  --nori-border-active: #a1a1aa;
-  --nori-text: #18181b;
-  --nori-text-secondary: #52525b;
-  --nori-text-muted: #71717a;
-  --nori-text-subtle: #a1a1aa;
+  --nori-border: #e0e0e6;
+  --nori-border-strong: #cacad4;
+  --nori-border-active: #8b8d98;
+  --nori-text: #1a1a1e;
+  --nori-text-secondary: #5c5c65;
+  --nori-text-muted: #8b8d98;
+  --nori-text-subtle: #a8a8b3;
+  --nori-primary-bg: #1a1a1e;
+  --nori-primary-fg: #f9f9fb;
+  --nori-primary-hover: #2c2c32;
   --nori-shadow: none;
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);
-  --nori-shell: #fafafa;
+  --nori-shell: #f9f9fb;
   --nori-topbar: #ffffff;
-  --nori-statusbar: #f4f4f5;
-  --nori-control: #f4f4f5;
-  --nori-control-hover: #e4e4e7;
-  --nori-control-active: #d4d4d8;
+  --nori-statusbar: #f4f4f6;
+  --nori-control: #f4f4f6;
+  --nori-control-hover: #ececf0;
+  --nori-control-active: #e0e0e6;
   color-scheme: light;
 }
 
@@ -80,8 +95,73 @@
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--nori-cyan) 20%, transparent);
+  background: color-mix(in srgb, var(--nori-cyan) 24%, transparent);
   color: var(--nori-text);
+}
+
+/* ── Linear primary actions (light button on dark bg) ──────────────────── */
+
+.btn-primary {
+  background: var(--nori-primary-bg);
+  border-color: var(--nori-primary-bg);
+  color: var(--nori-primary-fg);
+}
+
+.btn-primary:hover {
+  background: var(--nori-primary-hover);
+  border-color: var(--nori-primary-hover);
+  color: var(--nori-primary-fg);
+  filter: none;
+}
+
+.chat-send-btn {
+  background: var(--nori-primary-bg);
+  color: var(--nori-primary-fg);
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  background: var(--nori-primary-hover);
+  color: var(--nori-primary-fg);
+}
+
+.chat-send-btn:disabled {
+  background: var(--nori-control-active);
+  color: var(--nori-text-muted);
+}
+
+.question-submit,
+.folder-picker-footer button.primary,
+.session-action-dialog footer button.primary,
+.mcp-elicitation-dock > footer button.primary {
+  background: var(--nori-primary-bg) !important;
+  border-color: var(--nori-primary-bg) !important;
+  color: var(--nori-primary-fg) !important;
+}
+
+/* Accent only for links & subtle highlights, not large fills */
+.view-eyebrow,
+.provider-settings-heading span,
+.settings-card-heading > span {
+  color: var(--nori-text-muted);
+}
+
+.starter-card svg,
+.welcome-mark,
+.sidebar-empty svg {
+  color: var(--nori-text-secondary);
+}
+
+.welcome-mark {
+  background: var(--nori-control);
+  border-color: var(--nori-border);
+}
+
+.markdown-view a {
+  color: var(--nori-cyan);
+}
+
+.status-accent {
+  color: var(--nori-text-secondary);
 }
 
 /* ── Shell layout ──────────────────────────────────────────────────────── */
@@ -114,7 +194,8 @@
 
 .app-logo {
   border-radius: var(--nori-radius-sm);
-  background: var(--nori-cyan);
+  background: var(--nori-primary-bg);
+  color: var(--nori-primary-fg);
   box-shadow: none;
 }
 
@@ -272,7 +353,7 @@ textarea.input:focus {
 }
 
 .chat-input-area:focus-within {
-  border-color: var(--nori-border-active);
+  border-color: var(--nori-border-strong);
   box-shadow: none;
 }
 
@@ -284,7 +365,8 @@ textarea.input:focus {
   transform: none;
   filter: none;
   box-shadow: none;
-  background: color-mix(in srgb, var(--nori-cyan) 88%, white);
+  background: var(--nori-primary-hover);
+  color: var(--nori-primary-fg);
 }
 
 .chat-jump-latest {
@@ -552,8 +634,7 @@ textarea.input:focus {
 /* ── Reduce motion on decorative transforms ────────────────────────────── */
 
 .provider-card:hover,
-.starter-card:hover,
-.chat-send-btn:hover:not(:disabled) {
+.starter-card:hover {
   transform: none;
 }
 

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,29 +5,29 @@
    ========================================================================== */
 
 :root {
-  /* Linear accent — indigo, used sparingly for links & focus */
-  --nori-cyan: #5E6AD2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
-  --nori-thinking: #8b8d98;
+  /* Chrome accent — neutral gray, not a brand hue */
+  --nori-cyan: #8b8b8b;
+  --nori-cyan-dim: rgba(255, 255, 255, 0.06);
+  --nori-thinking: #8b8b8b;
 
-  /* Linear cool dark palette */
-  --nori-bg: #0a0a0b;
-  --nori-surface: #101012;
-  --nori-surface-raised: #16161a;
-  --nori-surface-hover: #1c1c21;
-  --nori-bg-elevated: #16161a;
-  --nori-border: #2c2c30;
-  --nori-border-strong: #3a3a40;
-  --nori-border-active: #52525b;
-  --nori-text: #f0f0f3;
-  --nori-text-secondary: #8b8d98;
-  --nori-text-muted: #5c5c65;
-  --nori-text-subtle: #45454d;
+  /* Linear neutral dark palette (equal RGB channels) */
+  --nori-bg: #090909;
+  --nori-surface: #0f0f0f;
+  --nori-surface-raised: #141414;
+  --nori-surface-hover: #1a1a1a;
+  --nori-bg-elevated: #141414;
+  --nori-border: #262626;
+  --nori-border-strong: #333333;
+  --nori-border-active: #525252;
+  --nori-text: #ededed;
+  --nori-text-secondary: #8b8b8b;
+  --nori-text-muted: #5c5c5c;
+  --nori-text-subtle: #454545;
 
   /* Primary action — Linear uses light buttons on dark bg */
-  --nori-primary-bg: #e8e8ed;
-  --nori-primary-fg: #0a0a0b;
-  --nori-primary-hover: #f4f4f6;
+  --nori-primary-bg: #e8e8e8;
+  --nori-primary-fg: #090909;
+  --nori-primary-hover: #f5f5f5;
 
   /* Shape — smaller, consistent radii */
   --nori-radius: 6px;
@@ -39,13 +39,13 @@
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
 
   /* Shell tokens */
-  --nori-shell: #0a0a0b;
-  --nori-sidebar-bg: #0c0c0e;
-  --nori-topbar: #0a0a0b;
-  --nori-statusbar: #101012;
-  --nori-control: #16161a;
-  --nori-control-hover: #1c1c21;
-  --nori-control-active: #242429;
+  --nori-shell: #090909;
+  --nori-sidebar-bg: #090909;
+  --nori-topbar: #090909;
+  --nori-statusbar: #0f0f0f;
+  --nori-control: #141414;
+  --nori-control-hover: #1a1a1a;
+  --nori-control-active: #222222;
 
   /* Spacing scale */
   --nori-space-1: 4px;
@@ -59,8 +59,9 @@
 }
 
 [data-theme="light"] {
-  --nori-cyan: #4f57c7;
-  --nori-cyan-dim: rgba(79, 87, 199, 0.14);
+  --nori-cyan: #5c5c65;
+  --nori-cyan-dim: rgba(0, 0, 0, 0.06);
+  --nori-link: #3a3a3a;
   --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
   --nori-surface-raised: #f4f4f6;
@@ -97,7 +98,7 @@
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--nori-cyan) 24%, transparent);
+  background: rgba(255, 255, 255, 0.12);
   color: var(--nori-text);
 }
 
@@ -159,7 +160,9 @@
 }
 
 .markdown-view a {
-  color: var(--nori-cyan);
+  color: var(--nori-text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .status-accent {
@@ -297,19 +300,6 @@
   background: var(--nori-control-hover);
 }
 
-.btn:active {
-  transform: none;
-}
-
-.btn-primary {
-  font-weight: 600;
-}
-
-.btn-primary:hover {
-  filter: none;
-  background: color-mix(in srgb, var(--nori-cyan) 88%, white);
-}
-
 .btn-secondary:hover {
   border-color: var(--nori-border-strong);
 }
@@ -356,6 +346,11 @@ textarea.input:focus {
 .settings-notice-icon,
 .provider-card-mark {
   border-radius: var(--nori-radius-sm);
+}
+
+.provider-card-mark {
+  color: var(--nori-text-secondary);
+  background: var(--nori-control);
 }
 
 /* ── Lists & sidebar empty states ──────────────────────────────────────── */
@@ -680,6 +675,8 @@ textarea.input:focus {
 
 .cron-job-icon {
   border-radius: var(--nori-radius-sm);
+  color: var(--nori-text-secondary);
+  background: var(--nori-control);
 }
 
 /* ── Inspector ───────────────────────────────────────────────────────────── */
@@ -749,4 +746,40 @@ textarea.input:focus {
   letter-spacing: 0;
   font-weight: 500;
   color: var(--nori-text-muted);
+}
+
+/* ── Neutralize legacy teal / purple chrome accents ──────────────────────── */
+
+.goal-island-icon {
+  color: var(--nori-text-secondary);
+  background: var(--nori-control);
+}
+
+.streaming-cursor {
+  background: var(--nori-text-muted);
+}
+
+.badge-info {
+  background: var(--nori-control);
+  color: var(--nori-text-secondary);
+}
+
+.spinner {
+  border-top-color: var(--nori-text-muted);
+}
+
+.chat-message-role span {
+  color: var(--nori-text-muted);
+}
+
+.chat-turn-rail button:focus-visible i {
+  background: var(--nori-border-strong);
+}
+
+.composer-usage i b {
+  background: var(--nori-text-muted);
+}
+
+.nav-btn.active {
+  box-shadow: none;
 }

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,12 +5,19 @@
    ========================================================================== */
 
 :root {
-  /* Chrome accent — neutral gray, not a brand hue */
-  --nori-cyan: #8b8b8b;
-  --nori-cyan-dim: rgba(255, 255, 255, 0.06);
+  /* Chrome accent — restrained indigo for edges & highlights */
+  --nori-cyan: #6b72d6;
+  --nori-cyan-dim: rgba(107, 114, 214, 0.12);
   --nori-thinking: #8b8b8b;
+  --nori-accent: #6b72d6;
+  --nori-accent-dim: rgba(107, 114, 214, 0.12);
+  --nori-accent-edge: rgba(107, 114, 214, 0.32);
+  --nori-accent-soft: rgba(107, 114, 214, 0.06);
+  --nori-shell-gradient:
+    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(94, 106, 210, 0.07), transparent 52%),
+    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(124, 92, 255, 0.05), transparent 48%);
 
-  /* Linear neutral dark palette (equal RGB channels) */
+  /* Neutral dark palette — purple only via gradients above */
   --nori-bg: #090909;
   --nori-surface: #0f0f0f;
   --nori-surface-raised: #141414;
@@ -59,9 +66,16 @@
 }
 
 [data-theme="light"] {
-  --nori-cyan: #5c5c65;
-  --nori-cyan-dim: rgba(0, 0, 0, 0.06);
-  --nori-link: #3a3a3a;
+  --nori-cyan: #5e6ad2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent: #5e6ad2;
+  --nori-accent-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent-edge: rgba(94, 106, 210, 0.28);
+  --nori-accent-soft: rgba(94, 106, 210, 0.05);
+  --nori-shell-gradient:
+    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(94, 106, 210, 0.05), transparent 50%),
+    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(124, 92, 255, 0.04), transparent 45%);
+  --nori-link: #4f57c7;
   --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
   --nori-surface-raised: #f4f4f6;
@@ -93,12 +107,12 @@
 /* ── Focus & selection ─────────────────────────────────────────────────── */
 
 :focus-visible {
-  outline: 1px solid var(--nori-border-active);
+  outline: 1px solid color-mix(in srgb, var(--nori-accent) 55%, var(--nori-border-active));
   outline-offset: 1px;
 }
 
 ::selection {
-  background: rgba(255, 255, 255, 0.12);
+  background: color-mix(in srgb, var(--nori-accent) 28%, transparent);
   color: var(--nori-text);
 }
 
@@ -151,31 +165,42 @@
 .starter-card svg,
 .welcome-mark,
 .sidebar-empty svg {
-  color: var(--nori-text-secondary);
+  color: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-text-secondary));
 }
 
 .welcome-mark {
-  background: var(--nori-control);
-  border-color: var(--nori-border);
+  border-color: color-mix(in srgb, var(--nori-accent) 28%, var(--nori-border));
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--nori-accent) 14%, transparent), color-mix(in srgb, var(--nori-accent) 3%, transparent)),
+    var(--nori-control);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18), inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 18%, transparent);
 }
 
 .markdown-view a {
-  color: var(--nori-text);
+  color: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text));
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .status-accent {
-  color: var(--nori-text-secondary);
+  color: color-mix(in srgb, var(--nori-accent) 70%, var(--nori-text-secondary));
 }
 
 /* ── Shell layout ──────────────────────────────────────────────────────── */
 
+.codex-layout {
+  background-color: var(--nori-bg);
+  background-image: var(--nori-shell-gradient);
+}
+
 .codex-layout .sidebar,
 .sidebar {
-  background: var(--nori-sidebar-bg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 5%, transparent) 0%, transparent 30%),
+    var(--nori-sidebar-bg);
   backdrop-filter: none;
-  border-right: 1px solid var(--nori-border);
+  border-right: 1px solid color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border));
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--nori-accent) 10%, transparent);
 }
 
 [data-theme="light"] .codex-layout .sidebar,
@@ -196,8 +221,9 @@
 .codex-layout .sidebar-nav-item.active,
 .codex-layout .sidebar-tab.active,
 .sidebar-nav-item.active {
-  background: var(--nori-control-active);
+  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-active));
   color: var(--nori-text);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 16%, transparent);
 }
 
 .codex-layout .sidebar-nav-item,
@@ -208,9 +234,12 @@
 
 .top-bar {
   height: 48px;
-  background: var(--nori-topbar);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 70%),
+    var(--nori-topbar);
   backdrop-filter: none;
-  border-bottom: 1px solid var(--nori-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--nori-accent) 8%, transparent);
 }
 
 [data-theme="light"] .top-bar {
@@ -257,15 +286,15 @@
 }
 
 .sidebar-item.active {
-  border-color: var(--nori-border);
-  background: var(--nori-control-hover);
+  border-color: color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border));
+  background: color-mix(in srgb, var(--nori-accent) 8%, var(--nori-control-hover));
   color: var(--nori-text);
 }
 
 .nav-btn.active {
-  background: var(--nori-control-hover);
+  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-hover));
   color: var(--nori-text);
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 14%, transparent);
 }
 
 .mode-toggle-bar {
@@ -348,11 +377,6 @@ textarea.input:focus {
   border-radius: var(--nori-radius-sm);
 }
 
-.provider-card-mark {
-  color: var(--nori-text-secondary);
-  background: var(--nori-control);
-}
-
 /* ── Lists & sidebar empty states ──────────────────────────────────────── */
 
 .sidebar-empty {
@@ -364,19 +388,21 @@ textarea.input:focus {
 /* ── Chat ──────────────────────────────────────────────────────────────── */
 
 .chat-composer-wrap {
-  background: var(--nori-bg);
+  background: linear-gradient(transparent, var(--nori-bg) 24%);
 }
 
 .chat-input-area {
   border-radius: var(--nori-radius);
   background: var(--nori-surface);
   box-shadow: none;
-  transition: border-color 0.12s ease;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
 .chat-input-area:focus-within {
-  border-color: var(--nori-border-strong);
-  box-shadow: none;
+  border-color: color-mix(in srgb, var(--nori-accent) 42%, var(--nori-border-strong));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--nori-accent) 12%, transparent),
+    0 8px 28px color-mix(in srgb, var(--nori-accent) 8%, transparent);
 }
 
 .chat-send-btn {
@@ -410,8 +436,8 @@ textarea.input:focus {
 
 .starter-card:hover {
   transform: none;
-  border-color: var(--nori-border-strong);
-  box-shadow: none;
+  border-color: color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border-strong));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--nori-accent) 8%, transparent);
   background: var(--nori-control-hover);
 }
 
@@ -528,8 +554,8 @@ textarea.input:focus {
 
 .sidebar-item.active,
 .codex-layout .sidebar-item.active {
-  border-color: transparent;
-  background: var(--nori-control-hover);
+  border-color: color-mix(in srgb, var(--nori-accent) 16%, transparent);
+  background: color-mix(in srgb, var(--nori-accent) 8%, var(--nori-control-hover));
   color: var(--nori-text);
 }
 
@@ -555,22 +581,28 @@ textarea.input:focus {
 }
 
 .inspector-navigation {
-  border: 1px solid var(--nori-border);
+  border: 1px solid color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border));
   border-radius: var(--nori-radius);
-  background: var(--nori-surface);
-  box-shadow: none;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 5%, transparent), transparent 28%),
+    var(--nori-surface);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 12%, transparent),
+    0 0 28px color-mix(in srgb, var(--nori-accent) 5%, transparent);
 }
 
 .inspector-navigation.compact {
   border-radius: var(--nori-radius);
-  box-shadow: none;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 12%, transparent),
+    0 0 24px color-mix(in srgb, var(--nori-accent) 6%, transparent);
 }
 
 .inspector-stage {
-  border: 1px solid var(--nori-border);
+  border: 1px solid color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
   border-radius: var(--nori-radius);
   background: var(--nori-surface);
-  box-shadow: none;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 8%, transparent);
 }
 
 .inspector-stage.open {
@@ -599,18 +631,19 @@ textarea.input:focus {
 }
 
 .inspector-navigation.compact button.active {
-  color: var(--nori-text);
-  background: var(--nori-control-active);
+  color: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text));
+  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control-active));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 18%, transparent);
 }
 
 .inspector-navigation.compact .inspector-tab-list em {
-  background: var(--nori-control-active);
-  color: var(--nori-text-secondary);
+  background: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-control-active));
+  color: var(--nori-text);
 }
 
 .inspector-pin-button.active {
-  color: var(--nori-text);
-  background: var(--nori-control-hover);
+  color: color-mix(in srgb, var(--nori-accent) 80%, var(--nori-text));
+  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-hover));
 }
 
 .inspector-activity-icon,
@@ -620,7 +653,7 @@ textarea.input:focus {
 }
 
 .inspector-open-tab.active {
-  box-shadow: inset 0 -1px var(--nori-border-strong);
+  box-shadow: inset 0 -2px color-mix(in srgb, var(--nori-accent) 70%, var(--nori-border-strong));
 }
 
 .inspector-tool-menu {
@@ -675,8 +708,6 @@ textarea.input:focus {
 
 .cron-job-icon {
   border-radius: var(--nori-radius-sm);
-  color: var(--nori-text-secondary);
-  background: var(--nori-control);
 }
 
 /* ── Inspector ───────────────────────────────────────────────────────────── */
@@ -748,38 +779,80 @@ textarea.input:focus {
   color: var(--nori-text-muted);
 }
 
-/* ── Neutralize legacy teal / purple chrome accents ──────────────────────── */
+/* ── Subtle purple edge highlights ───────────────────────────────────────── */
+
+.sidebar-resizer::after,
+.workspace-inspector-resizer::after {
+  background: radial-gradient(
+    ellipse 2px 72px at center var(--resize-highlight-y),
+    color-mix(in srgb, var(--nori-accent) 62%, transparent) 0,
+    transparent 100%
+  );
+  opacity: 0.42;
+}
+
+.sidebar-resizer:hover::after,
+.sidebar-resizer:active::after,
+.workspace-inspector-resizer:hover::after,
+.workspace-inspector-resizer:focus-visible::after,
+.workspace-chat-layout.inspector-resizing .workspace-inspector-resizer::after {
+  opacity: 0.95;
+}
+
+.initial-usage {
+  border-color: color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border-strong));
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 32%),
+    color-mix(in srgb, var(--nori-surface-raised) 86%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 10%, transparent),
+    0 14px 38px rgba(0, 0, 0, 0.2);
+  backdrop-filter: none;
+}
+
+.goal-island {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 24%),
+    var(--nori-surface);
+  border-color: color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border-strong));
+}
 
 .goal-island-icon {
-  color: var(--nori-text-secondary);
-  background: var(--nori-control);
+  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
+  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
 }
 
 .streaming-cursor {
-  background: var(--nori-text-muted);
+  background: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text-muted));
 }
 
 .badge-info {
-  background: var(--nori-control);
-  color: var(--nori-text-secondary);
+  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
+  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
 }
 
 .spinner {
-  border-top-color: var(--nori-text-muted);
+  border-top-color: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-text-muted));
 }
 
 .chat-message-role span {
-  color: var(--nori-text-muted);
+  color: color-mix(in srgb, var(--nori-accent) 65%, var(--nori-text-muted));
 }
 
 .chat-turn-rail button:focus-visible i {
-  background: var(--nori-border-strong);
+  background: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-border-strong));
 }
 
 .composer-usage i b {
-  background: var(--nori-text-muted);
+  background: color-mix(in srgb, var(--nori-accent) 70%, var(--nori-text-muted));
 }
 
-.nav-btn.active {
-  box-shadow: none;
+.provider-card-mark {
+  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
+  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control));
+}
+
+.cron-job-icon {
+  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
+  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
 }

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,17 +5,19 @@
    ========================================================================== */
 
 :root {
-  /* Chrome accent — deeper indigo for edges & highlights */
-  --nori-cyan: #484dc4;
-  --nori-cyan-dim: rgba(72, 77, 196, 0.16);
+  /* Chrome accent — Linear lavender-indigo (#5e6ad2) */
+  --nori-cyan: #5e6ad2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.14);
   --nori-thinking: #8b8b8b;
-  --nori-accent: #484dc4;
-  --nori-accent-dim: rgba(72, 77, 196, 0.16);
-  --nori-accent-edge: rgba(72, 77, 196, 0.42);
-  --nori-accent-soft: rgba(72, 77, 196, 0.09);
+  --nori-accent: #5e6ad2;
+  --nori-accent-dim: rgba(94, 106, 210, 0.14);
+  --nori-accent-edge: rgba(94, 106, 210, 0.38);
+  --nori-accent-soft: rgba(94, 106, 210, 0.07);
+  --nori-accent-hover: #6f7ae0;
+  --nori-accent-focus: #5e69d1;
   --nori-shell-gradient:
-    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(72, 77, 196, 0.1), transparent 52%),
-    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(92, 72, 196, 0.07), transparent 48%);
+    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(94, 106, 210, 0.08), transparent 52%),
+    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(130, 143, 255, 0.05), transparent 48%);
 
   /* Neutral dark palette — purple only via gradients above */
   --nori-bg: #090909;
@@ -66,16 +68,18 @@
 }
 
 [data-theme="light"] {
-  --nori-cyan: #454ab8;
-  --nori-cyan-dim: rgba(69, 74, 184, 0.12);
-  --nori-accent: #454ab8;
-  --nori-accent-dim: rgba(69, 74, 184, 0.12);
-  --nori-accent-edge: rgba(69, 74, 184, 0.34);
-  --nori-accent-soft: rgba(69, 74, 184, 0.07);
+  --nori-cyan: #5e6ad2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent: #5e6ad2;
+  --nori-accent-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent-edge: rgba(94, 106, 210, 0.3);
+  --nori-accent-soft: rgba(94, 106, 210, 0.05);
+  --nori-accent-hover: #828fff;
+  --nori-accent-focus: #5e69d1;
   --nori-shell-gradient:
-    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(69, 74, 184, 0.07), transparent 50%),
-    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(92, 72, 196, 0.05), transparent 45%);
-  --nori-link: #3f44a8;
+    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(94, 106, 210, 0.06), transparent 50%),
+    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(130, 143, 255, 0.04), transparent 45%);
+  --nori-link: #5e6ad2;
   --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
   --nori-surface-raised: #f4f4f6;
@@ -107,7 +111,7 @@
 /* ── Focus & selection ─────────────────────────────────────────────────── */
 
 :focus-visible {
-  outline: 1px solid color-mix(in srgb, var(--nori-accent) 55%, var(--nori-border-active));
+  outline: 1px solid var(--nori-accent-focus);
   outline-offset: 1px;
 }
 

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,37 +5,27 @@
    ========================================================================== */
 
 :root {
-  /* Reference: Cursor / deep-violet UI — bright lavender accent on purple-tinted surfaces */
-  --nori-accent: #8b7cf8;
-  --nori-accent-bright: #a78bfa;
-  --nori-accent-focus: #9f8cff;
-  --nori-accent-hover: #9d8df9;
-  --nori-cyan: #8b7cf8;
-  --nori-cyan-dim: rgba(139, 124, 248, 0.16);
-  --nori-thinking: #9b8ec8;
-  --nori-accent-dim: rgba(139, 124, 248, 0.16);
-  --nori-accent-edge: rgba(167, 139, 250, 0.42);
-  --nori-accent-soft: rgba(139, 124, 248, 0.1);
-  --nori-accent-glow: rgba(139, 124, 248, 0.22);
-  --nori-rim-top: rgba(167, 139, 250, 0.24);
-  --nori-rim-side: rgba(167, 139, 250, 0.1);
-  --nori-shell-gradient:
-    radial-gradient(ellipse 130% 85% at 0% -5%, rgba(139, 124, 248, 0.14), transparent 54%),
-    radial-gradient(ellipse 95% 75% at 100% 105%, rgba(167, 139, 250, 0.1), transparent 50%);
+  /* Accent — sparse: edges, focus, active tab underline only */
+  --nori-accent: #5e6ad2;
+  --nori-cyan: #5e6ad2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent-dim: rgba(94, 106, 210, 0.1);
+  --nori-thinking: #8b8b8b;
+  --nori-shell-gradient: none;
 
-  /* Purple-tinted dark surfaces (not neutral gray) */
-  --nori-bg: #0c0c10;
-  --nori-surface: #12121a;
-  --nori-surface-raised: #16161f;
-  --nori-surface-hover: #1c1c28;
-  --nori-bg-elevated: #16161f;
-  --nori-border: #2a2a38;
-  --nori-border-strong: #36364a;
-  --nori-border-active: #4a4a62;
-  --nori-text: #f0f0f5;
-  --nori-text-secondary: #9b9bb0;
-  --nori-text-muted: #6b6b82;
-  --nori-text-subtle: #52526a;
+  /* Neutral gray palette — no purple tint in surfaces */
+  --nori-bg: #090909;
+  --nori-surface: #0f0f0f;
+  --nori-surface-raised: #141414;
+  --nori-surface-hover: #1a1a1a;
+  --nori-bg-elevated: #141414;
+  --nori-border: #262626;
+  --nori-border-strong: #333333;
+  --nori-border-active: #525252;
+  --nori-text: #ededed;
+  --nori-text-secondary: #8b8b8b;
+  --nori-text-muted: #5c5c5c;
+  --nori-text-subtle: #454545;
 
   /* Primary action — Linear uses light buttons on dark bg */
   --nori-primary-bg: #e8e8e8;
@@ -52,13 +42,13 @@
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
 
   /* Shell tokens */
-  --nori-shell: #0c0c10;
-  --nori-sidebar-bg: #0c0c10;
-  --nori-topbar: #0c0c10;
-  --nori-statusbar: #101018;
-  --nori-control: #16161f;
-  --nori-control-hover: #1c1c28;
-  --nori-control-active: #242432;
+  --nori-shell: #090909;
+  --nori-sidebar-bg: #090909;
+  --nori-topbar: #090909;
+  --nori-statusbar: #0f0f0f;
+  --nori-control: #141414;
+  --nori-control-hover: #1a1a1a;
+  --nori-control-active: #222222;
 
   /* Spacing scale */
   --nori-space-1: 4px;
@@ -115,12 +105,12 @@
 /* ── Focus & selection ─────────────────────────────────────────────────── */
 
 :focus-visible {
-  outline: 1px solid var(--nori-accent-focus);
+  outline: 1px solid color-mix(in srgb, var(--nori-accent) 45%, var(--nori-border-active));
   outline-offset: 1px;
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--nori-accent) 28%, transparent);
+  background: rgba(255, 255, 255, 0.12);
   color: var(--nori-text);
 }
 
@@ -173,25 +163,23 @@
 .starter-card svg,
 .welcome-mark,
 .sidebar-empty svg {
-  color: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-text-secondary));
+  color: var(--nori-text-secondary);
 }
 
 .welcome-mark {
-  border-color: color-mix(in srgb, var(--nori-accent) 28%, var(--nori-border));
-  background:
-    linear-gradient(145deg, color-mix(in srgb, var(--nori-accent) 14%, transparent), color-mix(in srgb, var(--nori-accent) 3%, transparent)),
-    var(--nori-control);
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18), inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 18%, transparent);
+  border-color: var(--nori-border);
+  background: var(--nori-control);
+  box-shadow: none;
 }
 
 .markdown-view a {
-  color: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text));
+  color: var(--nori-text);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .status-accent {
-  color: color-mix(in srgb, var(--nori-accent) 70%, var(--nori-text-secondary));
+  color: var(--nori-text-secondary);
 }
 
 /* ── Shell layout ──────────────────────────────────────────────────────── */
@@ -203,12 +191,10 @@
 
 .codex-layout .sidebar,
 .sidebar {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 5%, transparent) 0%, transparent 30%),
-    var(--nori-sidebar-bg);
+  background: var(--nori-sidebar-bg);
   backdrop-filter: none;
-  border-right: 1px solid color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border));
-  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--nori-accent) 10%, transparent);
+  border-right: 1px solid var(--nori-border);
+  box-shadow: none;
 }
 
 [data-theme="light"] .codex-layout .sidebar,
@@ -229,9 +215,9 @@
 .codex-layout .sidebar-nav-item.active,
 .codex-layout .sidebar-tab.active,
 .sidebar-nav-item.active {
-  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-active));
+  background: var(--nori-control-active);
   color: var(--nori-text);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 16%, transparent);
+  box-shadow: none;
 }
 
 .codex-layout .sidebar-nav-item,
@@ -242,12 +228,10 @@
 
 .top-bar {
   height: 48px;
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 70%),
-    var(--nori-topbar);
+  background: var(--nori-topbar);
   backdrop-filter: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--nori-accent) 8%, transparent);
+  border-bottom: 1px solid var(--nori-border);
+  box-shadow: none;
 }
 
 [data-theme="light"] .top-bar {
@@ -294,15 +278,15 @@
 }
 
 .sidebar-item.active {
-  border-color: color-mix(in srgb, var(--nori-accent) 18%, var(--nori-border));
-  background: color-mix(in srgb, var(--nori-accent) 8%, var(--nori-control-hover));
+  border-color: var(--nori-border);
+  background: var(--nori-control-hover);
   color: var(--nori-text);
 }
 
 .nav-btn.active {
-  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-hover));
+  background: var(--nori-control-hover);
   color: var(--nori-text);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 14%, transparent);
+  box-shadow: none;
 }
 
 .mode-toggle-bar {
@@ -407,10 +391,8 @@ textarea.input:focus {
 }
 
 .chat-input-area:focus-within {
-  border-color: color-mix(in srgb, var(--nori-accent) 42%, var(--nori-border-strong));
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--nori-accent) 12%, transparent),
-    0 8px 28px color-mix(in srgb, var(--nori-accent) 8%, transparent);
+  border-color: color-mix(in srgb, var(--nori-accent) 30%, var(--nori-border-strong));
+  box-shadow: 0 0 0 1px rgba(94, 106, 210, 0.1);
 }
 
 .chat-send-btn {
@@ -444,8 +426,8 @@ textarea.input:focus {
 
 .starter-card:hover {
   transform: none;
-  border-color: color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border-strong));
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--nori-accent) 8%, transparent);
+  border-color: var(--nori-border-strong);
+  box-shadow: none;
   background: var(--nori-control-hover);
 }
 
@@ -562,8 +544,8 @@ textarea.input:focus {
 
 .sidebar-item.active,
 .codex-layout .sidebar-item.active {
-  border-color: color-mix(in srgb, var(--nori-accent) 16%, transparent);
-  background: color-mix(in srgb, var(--nori-accent) 8%, var(--nori-control-hover));
+  border-color: transparent;
+  background: var(--nori-control-hover);
   color: var(--nori-text);
 }
 
@@ -589,28 +571,22 @@ textarea.input:focus {
 }
 
 .inspector-navigation {
-  border: 1px solid color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border));
+  border: 1px solid var(--nori-border);
   border-radius: var(--nori-radius);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 5%, transparent), transparent 28%),
-    var(--nori-surface);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 12%, transparent),
-    0 0 28px color-mix(in srgb, var(--nori-accent) 5%, transparent);
+  background: var(--nori-surface);
+  box-shadow: none;
 }
 
 .inspector-navigation.compact {
   border-radius: var(--nori-radius);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 12%, transparent),
-    0 0 24px color-mix(in srgb, var(--nori-accent) 6%, transparent);
+  box-shadow: none;
 }
 
 .inspector-stage {
-  border: 1px solid color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
+  border: 1px solid var(--nori-border);
   border-radius: var(--nori-radius);
   background: var(--nori-surface);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 8%, transparent);
+  box-shadow: none;
 }
 
 .inspector-stage.open {
@@ -639,19 +615,19 @@ textarea.input:focus {
 }
 
 .inspector-navigation.compact button.active {
-  color: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text));
-  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control-active));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 18%, transparent);
+  color: var(--nori-text);
+  background: var(--nori-control-active);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 20%, var(--nori-border));
 }
 
 .inspector-navigation.compact .inspector-tab-list em {
-  background: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-control-active));
-  color: var(--nori-text);
+  background: var(--nori-control-active);
+  color: var(--nori-text-secondary);
 }
 
 .inspector-pin-button.active {
-  color: color-mix(in srgb, var(--nori-accent) 80%, var(--nori-text));
-  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control-hover));
+  color: var(--nori-text);
+  background: var(--nori-control-hover);
 }
 
 .inspector-activity-icon,
@@ -661,7 +637,7 @@ textarea.input:focus {
 }
 
 .inspector-open-tab.active {
-  box-shadow: inset 0 -2px color-mix(in srgb, var(--nori-accent) 70%, var(--nori-border-strong));
+  box-shadow: inset 0 -2px var(--nori-accent);
 }
 
 .inspector-tool-menu {
@@ -787,16 +763,16 @@ textarea.input:focus {
   color: var(--nori-text-muted);
 }
 
-/* ── Subtle purple edge highlights ───────────────────────────────────────── */
+/* ── Sparse purple accents (edges & focus only) ──────────────────────────── */
 
 .sidebar-resizer::after,
 .workspace-inspector-resizer::after {
   background: radial-gradient(
     ellipse 2px 72px at center var(--resize-highlight-y),
-    color-mix(in srgb, var(--nori-accent) 62%, transparent) 0,
+    color-mix(in srgb, var(--nori-accent) 50%, transparent) 0,
     transparent 100%
   );
-  opacity: 0.42;
+  opacity: 0.28;
 }
 
 .sidebar-resizer:hover::after,
@@ -804,167 +780,71 @@ textarea.input:focus {
 .workspace-inspector-resizer:hover::after,
 .workspace-inspector-resizer:focus-visible::after,
 .workspace-chat-layout.inspector-resizing .workspace-inspector-resizer::after {
-  opacity: 1;
+  opacity: 0.75;
 }
 
-.initial-usage {
-  backdrop-filter: none;
-}
-
-.goal-island {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--nori-accent) 4%, transparent), transparent 24%),
-    var(--nori-surface);
-  border-color: color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border-strong));
-}
-
-.goal-island-icon {
-  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
-  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
+.goal-island-icon,
+.streaming-cursor,
+.badge-info,
+.spinner,
+.chat-message-role span,
+.chat-turn-rail button:focus-visible i,
+.composer-usage i b,
+.provider-card-mark,
+.cron-job-icon {
+  color: var(--nori-text-secondary);
+  background: var(--nori-control);
 }
 
 .streaming-cursor {
-  background: color-mix(in srgb, var(--nori-accent) 82%, var(--nori-text-muted));
-}
-
-.badge-info {
-  background: color-mix(in srgb, var(--nori-accent) 12%, var(--nori-control));
-  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
+  background: var(--nori-text-muted);
 }
 
 .spinner {
-  border-top-color: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-text-muted));
-}
-
-.chat-message-role span {
-  color: color-mix(in srgb, var(--nori-accent) 65%, var(--nori-text-muted));
-}
-
-.chat-turn-rail button:focus-visible i {
-  background: color-mix(in srgb, var(--nori-accent) 72%, var(--nori-border-strong));
+  border-top-color: var(--nori-text-muted);
 }
 
 .composer-usage i b {
-  background: color-mix(in srgb, var(--nori-accent) 70%, var(--nori-text-muted));
+  background: var(--nori-text-muted);
 }
 
-.provider-card-mark {
-  color: color-mix(in srgb, var(--nori-accent) 78%, var(--nori-text-secondary));
-  background: color-mix(in srgb, var(--nori-accent) 10%, var(--nori-control));
-}
+/* nori-theme .codex-layout rules load before this file — win on conflicts */
 
-.cron-job-icon {
-  color: var(--nori-accent-bright);
-  background: color-mix(in srgb, var(--nori-accent) 14%, var(--nori-control));
-}
-
-/* ── Reference match: high-specificity shell overrides ───────────────────── */
-/* nori-theme.css ships later .codex-layout rules — these must win. */
-
-.codex-layout .chat-welcome .welcome-mark,
-.chat-welcome .welcome-mark {
-  color: var(--nori-accent-bright);
-  border: 1px solid color-mix(in srgb, var(--nori-accent-bright) 42%, var(--nori-border));
-  background:
-    linear-gradient(145deg, rgba(139, 124, 248, 0.24), rgba(139, 124, 248, 0.06)),
-    var(--nori-control);
-  box-shadow:
-    0 0 36px var(--nori-accent-glow),
-    inset 0 1px 0 var(--nori-rim-top);
-}
-
-.starter-card svg {
-  color: var(--nori-accent-bright);
-}
-
-.starter-card {
-  border-color: color-mix(in srgb, var(--nori-accent) 16%, var(--nori-border));
-  background: linear-gradient(180deg, rgba(139, 124, 248, 0.04), transparent 40%), var(--nori-surface);
-  box-shadow: inset 0 1px 0 var(--nori-rim-top);
-}
-
-.codex-layout .sidebar-nav-item.active,
-.codex-layout .sidebar-tab.active,
-.codex-layout .sidebar-item.active {
-  color: var(--nori-text);
-  background: rgba(139, 124, 248, 0.14);
-  box-shadow:
-    inset 0 0 0 1px rgba(167, 139, 250, 0.28),
-    inset 0 1px 0 rgba(167, 139, 250, 0.12);
-}
-
-.codex-layout .sidebar-workspace-switch .sidebar-tab.active {
-  background: rgba(139, 124, 248, 0.16);
-  border-color: rgba(167, 139, 250, 0.32);
-  box-shadow: inset 0 1px 0 var(--nori-rim-top);
+.codex-layout .chat-welcome .welcome-mark {
+  color: var(--nori-text-secondary);
+  border-color: var(--nori-border);
+  background: var(--nori-control);
+  box-shadow: none;
 }
 
 .codex-layout .chat-input-area {
-  border: 1px solid color-mix(in srgb, var(--nori-accent) 22%, var(--nori-border-strong));
-  background: linear-gradient(180deg, rgba(139, 124, 248, 0.05), transparent 36%), var(--nori-control);
-  box-shadow:
-    inset 0 1px 0 var(--nori-rim-top),
-    0 14px 38px rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--nori-border-strong);
+  background: var(--nori-control);
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.18);
   backdrop-filter: none;
 }
 
 .codex-layout .chat-input-area:focus-within {
-  border-color: color-mix(in srgb, var(--nori-accent-bright) 58%, var(--nori-border-strong));
+  border-color: color-mix(in srgb, var(--nori-accent) 32%, var(--nori-border-strong));
   box-shadow:
-    inset 0 1px 0 var(--nori-rim-top),
-    0 0 0 1px rgba(139, 124, 248, 0.2),
-    0 0 32px var(--nori-accent-glow),
-    0 16px 42px rgba(0, 0, 0, 0.24);
+    0 16px 42px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(94, 106, 210, 0.14);
 }
 
 .initial-usage {
-  border: 1px solid color-mix(in srgb, var(--nori-accent-bright) 34%, var(--nori-border-strong));
-  background:
-    linear-gradient(180deg, rgba(139, 124, 248, 0.1), transparent 38%),
-    color-mix(in srgb, var(--nori-surface-raised) 92%, transparent);
-  box-shadow:
-    inset 0 1px 0 var(--nori-rim-top),
-    0 0 40px rgba(139, 124, 248, 0.1),
-    0 14px 38px rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--nori-border-strong);
+  background: color-mix(in srgb, var(--nori-surface-raised) 86%, transparent);
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.2);
+  backdrop-filter: none;
 }
 
 .initial-usage-metrics > div {
-  border-color: color-mix(in srgb, var(--nori-accent) 14%, var(--nori-border));
-  background: linear-gradient(180deg, rgba(139, 124, 248, 0.04), transparent), var(--nori-control);
-  box-shadow: inset 0 1px 0 rgba(167, 139, 250, 0.08);
+  border-color: var(--nori-border);
+  background: var(--nori-control);
+  box-shadow: none;
 }
 
-.inspector-stage.open {
-  border-color: color-mix(in srgb, var(--nori-accent-bright) 28%, var(--nori-border));
-  box-shadow:
-    inset 0 1px 0 var(--nori-rim-top),
-    0 0 36px rgba(139, 124, 248, 0.08);
-}
-
-.inspector-navigation.compact {
-  border-color: color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border));
-  box-shadow:
-    inset 0 1px 0 var(--nori-rim-top),
-    0 0 28px rgba(139, 124, 248, 0.1);
-}
-
-.inspector-navigation.compact button.active {
-  color: var(--nori-accent-bright);
-  background: rgba(139, 124, 248, 0.2);
-  box-shadow:
-    inset 0 0 0 1px rgba(167, 139, 250, 0.36),
-    0 0 18px rgba(139, 124, 248, 0.14);
-}
-
-.codex-layout .inspector-open-tab.active {
-  color: var(--nori-text);
-  box-shadow: inset 0 -2px var(--nori-accent-bright);
-}
-
+.codex-layout .inspector-open-tab.active,
 .inspector-open-tab.active {
-  box-shadow: inset 0 -2px var(--nori-accent-bright);
-}
-
-.inspector-content {
-  background: var(--nori-bg);
+  box-shadow: inset 0 -2px var(--nori-accent);
 }

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -1,0 +1,520 @@
+/* ==========================================================================
+   Linear-inspired flat design overrides for Nori Web
+   Scope: visual style only — no interaction or layout structure changes.
+   Priority: shell → nav → primitives → chat → dialogs → settings pages
+   ========================================================================== */
+
+:root {
+  /* Linear-like neutral palette */
+  --nori-bg: #09090b;
+  --nori-surface: #111113;
+  --nori-surface-raised: #18181b;
+  --nori-surface-hover: #1f1f23;
+  --nori-bg-elevated: #18181b;
+  --nori-border: #27272a;
+  --nori-border-strong: #3f3f46;
+  --nori-border-active: #52525b;
+  --nori-text: #fafafa;
+  --nori-text-secondary: #a1a1aa;
+  --nori-text-muted: #71717a;
+  --nori-text-subtle: #52525b;
+
+  /* Shape — smaller, consistent radii */
+  --nori-radius: 6px;
+  --nori-radius-sm: 4px;
+
+  /* Flat elevation — borders over shadows */
+  --nori-shadow: none;
+  --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.32);
+  --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
+
+  /* Shell tokens */
+  --nori-shell: #09090b;
+  --nori-topbar: #09090b;
+  --nori-statusbar: #111113;
+  --nori-control: #18181b;
+  --nori-control-hover: #1f1f23;
+  --nori-control-active: #27272a;
+
+  /* Spacing scale */
+  --nori-space-1: 4px;
+  --nori-space-2: 8px;
+  --nori-space-3: 12px;
+  --nori-space-4: 16px;
+  --nori-space-5: 20px;
+  --nori-space-6: 24px;
+
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  --nori-bg: #fafafa;
+  --nori-surface: #ffffff;
+  --nori-surface-raised: #f4f4f5;
+  --nori-surface-hover: #f4f4f5;
+  --nori-bg-elevated: #ffffff;
+  --nori-border: #e4e4e7;
+  --nori-border-strong: #d4d4d8;
+  --nori-border-active: #a1a1aa;
+  --nori-text: #18181b;
+  --nori-text-secondary: #52525b;
+  --nori-text-muted: #71717a;
+  --nori-text-subtle: #a1a1aa;
+  --nori-shadow: none;
+  --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+  --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --nori-shell: #fafafa;
+  --nori-topbar: #ffffff;
+  --nori-statusbar: #f4f4f5;
+  --nori-control: #f4f4f5;
+  --nori-control-hover: #e4e4e7;
+  --nori-control-active: #d4d4d8;
+  color-scheme: light;
+}
+
+/* ── Focus & selection ─────────────────────────────────────────────────── */
+
+:focus-visible {
+  outline: 1px solid var(--nori-border-active);
+  outline-offset: 1px;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--nori-cyan) 20%, transparent);
+  color: var(--nori-text);
+}
+
+/* ── Shell layout ──────────────────────────────────────────────────────── */
+
+.sidebar {
+  background: var(--nori-shell);
+  backdrop-filter: none;
+  border-right: 1px solid var(--nori-border);
+}
+
+[data-theme="light"] .sidebar {
+  background: var(--nori-shell);
+}
+
+.top-bar {
+  height: 48px;
+  background: var(--nori-topbar);
+  backdrop-filter: none;
+  border-bottom: 1px solid var(--nori-border);
+}
+
+[data-theme="light"] .top-bar {
+  background: var(--nori-topbar);
+}
+
+.status-bar {
+  background: var(--nori-statusbar);
+  border-top: 1px solid var(--nori-border);
+}
+
+.app-logo {
+  border-radius: var(--nori-radius-sm);
+  background: var(--nori-cyan);
+  box-shadow: none;
+}
+
+.app-logo::after {
+  display: none;
+}
+
+/* ── Navigation ────────────────────────────────────────────────────────── */
+
+.sidebar-tab,
+.sidebar-item,
+.sidebar-toggle,
+.nav-btn {
+  border-radius: var(--nori-radius-sm);
+}
+
+.sidebar-tab.active {
+  background: var(--nori-control-hover);
+  color: var(--nori-text);
+}
+
+.sidebar-item {
+  border: 1px solid transparent;
+}
+
+.sidebar-item:hover {
+  border-color: var(--nori-border);
+  background: var(--nori-control-hover);
+}
+
+.sidebar-item.active {
+  border-color: var(--nori-border);
+  background: var(--nori-control-hover);
+  color: var(--nori-text);
+}
+
+.nav-btn.active {
+  background: var(--nori-control-hover);
+  color: var(--nori-text);
+  box-shadow: none;
+}
+
+.mode-toggle-bar {
+  border-radius: var(--nori-radius-sm);
+  padding: 2px;
+}
+
+.mode-toggle-btn {
+  border-radius: var(--nori-radius-sm);
+}
+
+.mode-toggle-btn.active {
+  background: var(--nori-control-active);
+  box-shadow: none;
+}
+
+.session-chip {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Buttons ───────────────────────────────────────────────────────────── */
+
+.btn {
+  border-radius: var(--nori-radius-sm);
+  font-weight: 500;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.btn:hover {
+  border-color: var(--nori-border-strong);
+  color: var(--nori-text);
+  background: var(--nori-control-hover);
+}
+
+.btn:active {
+  transform: none;
+}
+
+.btn-primary {
+  font-weight: 600;
+}
+
+.btn-primary:hover {
+  filter: none;
+  background: color-mix(in srgb, var(--nori-cyan) 88%, white);
+}
+
+.btn-secondary:hover {
+  border-color: var(--nori-border-strong);
+}
+
+.btn-icon {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Inputs ────────────────────────────────────────────────────────────── */
+
+.input,
+textarea.input,
+select.input {
+  border-radius: var(--nori-radius-sm);
+  background: var(--nori-control);
+  transition: border-color 0.12s ease;
+}
+
+.input:focus,
+textarea.input:focus {
+  box-shadow: none;
+  border-color: var(--nori-border-active);
+}
+
+/* ── Cards ─────────────────────────────────────────────────────────────── */
+
+.card {
+  border-radius: var(--nori-radius);
+  box-shadow: none;
+}
+
+.card:hover {
+  border-color: var(--nori-border-strong);
+}
+
+.settings-card,
+.settings-notice,
+.provider-card,
+.provider-editor {
+  border-radius: var(--nori-radius);
+  box-shadow: none;
+}
+
+.settings-notice-icon,
+.provider-card-mark {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Lists & sidebar empty states ──────────────────────────────────────── */
+
+.sidebar-empty {
+  border-radius: var(--nori-radius);
+  border-style: solid;
+  border-color: var(--nori-border);
+}
+
+/* ── Chat ──────────────────────────────────────────────────────────────── */
+
+.chat-composer-wrap {
+  background: var(--nori-bg);
+}
+
+.chat-input-area {
+  border-radius: var(--nori-radius);
+  background: var(--nori-surface);
+  box-shadow: none;
+  transition: border-color 0.12s ease;
+}
+
+.chat-input-area:focus-within {
+  border-color: var(--nori-border-active);
+  box-shadow: none;
+}
+
+.chat-send-btn {
+  border-radius: var(--nori-radius-sm);
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  transform: none;
+  filter: none;
+  box-shadow: none;
+  background: color-mix(in srgb, var(--nori-cyan) 88%, white);
+}
+
+.chat-jump-latest {
+  box-shadow: var(--nori-shadow-popover);
+  border-color: var(--nori-border);
+}
+
+.welcome-mark {
+  border-radius: var(--nori-radius);
+  background: var(--nori-control);
+  box-shadow: none;
+  border-color: var(--nori-border);
+}
+
+.starter-card {
+  border-radius: var(--nori-radius);
+  background: var(--nori-surface);
+}
+
+.starter-card:hover {
+  transform: none;
+  border-color: var(--nori-border-strong);
+  box-shadow: none;
+  background: var(--nori-control-hover);
+}
+
+.message-avatar {
+  border-radius: var(--nori-radius-sm);
+}
+
+.chat-message-thinking,
+.tool-call {
+  border-radius: var(--nori-radius-sm);
+}
+
+.chat-turn-preview {
+  border-radius: var(--nori-radius);
+  box-shadow: var(--nori-shadow-popover);
+}
+
+.chat-turn-rail button:hover i,
+.chat-turn-rail button.active i {
+  box-shadow: none;
+}
+
+.goal-island {
+  border-radius: var(--nori-radius);
+  box-shadow: none;
+  background: var(--nori-surface);
+}
+
+/* ── Dialogs & overlays ────────────────────────────────────────────────── */
+
+.folder-picker-backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: none;
+}
+
+.folder-picker {
+  border-radius: var(--nori-radius);
+  box-shadow: var(--nori-shadow-lg);
+}
+
+.session-context-menu,
+.file-context-menu {
+  border-radius: var(--nori-radius-sm);
+  border-color: var(--nori-border);
+  box-shadow: var(--nori-shadow-popover);
+}
+
+.approval-dock,
+.question-dock,
+.mcp-elicitation-dock {
+  border-radius: var(--nori-radius);
+  box-shadow: none;
+}
+
+/* ── View pages ────────────────────────────────────────────────────────── */
+
+.view-page {
+  padding: var(--nori-space-6) clamp(20px, 4vw, 48px);
+}
+
+.view-header h1 {
+  font-weight: 600;
+}
+
+.view-eyebrow {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* ── Provider status dots — flat ring ──────────────────────────────────── */
+
+.provider-status {
+  box-shadow: none;
+}
+
+.provider-status-connected,
+.provider-status-error,
+.provider-status-disabled {
+  box-shadow: none;
+}
+
+/* ── Dashboard & swarm ─────────────────────────────────────────────────── */
+
+.phase-bar,
+.swarm-run-card,
+.cron-job-card {
+  border-radius: var(--nori-radius);
+}
+
+/* ── Account center tabs ───────────────────────────────────────────────── */
+
+.account-tabs button {
+  border-radius: var(--nori-radius-sm);
+}
+
+.account-tabs button.active {
+  box-shadow: none;
+}
+
+/* ── Inspector panels ──────────────────────────────────────────────────── */
+
+.inspector-tabs button {
+  border-radius: var(--nori-radius-sm);
+}
+
+.inspector-tabs button.active {
+  box-shadow: none;
+}
+
+.codex-layout .inspector-pane {
+  border-left: 1px solid var(--nori-border);
+}
+
+/* ── Reduce motion on decorative transforms ────────────────────────────── */
+
+.provider-card:hover,
+.starter-card:hover,
+.chat-send-btn:hover:not(:disabled) {
+  transform: none;
+}
+
+/* ── Session dialogs ───────────────────────────────────────────────────── */
+
+.session-action-dialog {
+  border-radius: var(--nori-radius);
+  box-shadow: var(--nori-shadow-lg);
+}
+
+/* ── Cron jobs ───────────────────────────────────────────────────────────── */
+
+.cron-job-card {
+  border-radius: var(--nori-radius);
+}
+
+.cron-job-icon {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Inspector ───────────────────────────────────────────────────────────── */
+
+.inspector-pin-button {
+  border-radius: var(--nori-radius-sm);
+}
+
+.inspector-pin-button:hover {
+  transform: none;
+}
+
+.workspace-inspector {
+  border-left: 1px solid var(--nori-border);
+}
+
+/* ── File tree ───────────────────────────────────────────────────────────── */
+
+.file-tree-row {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Toggle switch — flat track ──────────────────────────────────────────── */
+
+.toggle input:checked + .toggle-slider {
+  box-shadow: none;
+}
+
+/* ── Badges — flat pills ─────────────────────────────────────────────────── */
+
+.badge {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Phase bar ───────────────────────────────────────────────────────────── */
+
+.phase-bar {
+  border-radius: var(--nori-radius);
+}
+
+.phase-bar button {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Vault graph ───────────────────────────────────────────────────────── */
+
+.vault-graph {
+  border-radius: var(--nori-radius);
+}
+
+/* ── Swarm preview ───────────────────────────────────────────────────────── */
+
+.swarm-preview-notice {
+  border-radius: var(--nori-radius-sm);
+}
+
+/* ── Top bar height consistency ────────────────────────────────────────── */
+
+.sidebar-brand {
+  height: 48px;
+}
+
+.sidebar-tabs {
+  padding-top: var(--nori-space-2);
+}
+
+/* ── Card header — Linear-style section labels ───────────────────────────── */
+
+.card-header {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 500;
+  color: var(--nori-text-muted);
+}

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,17 +5,17 @@
    ========================================================================== */
 
 :root {
-  /* Chrome accent — restrained indigo for edges & highlights */
-  --nori-cyan: #6b72d6;
-  --nori-cyan-dim: rgba(107, 114, 214, 0.12);
+  /* Chrome accent — deeper indigo for edges & highlights */
+  --nori-cyan: #484dc4;
+  --nori-cyan-dim: rgba(72, 77, 196, 0.16);
   --nori-thinking: #8b8b8b;
-  --nori-accent: #6b72d6;
-  --nori-accent-dim: rgba(107, 114, 214, 0.12);
-  --nori-accent-edge: rgba(107, 114, 214, 0.32);
-  --nori-accent-soft: rgba(107, 114, 214, 0.06);
+  --nori-accent: #484dc4;
+  --nori-accent-dim: rgba(72, 77, 196, 0.16);
+  --nori-accent-edge: rgba(72, 77, 196, 0.42);
+  --nori-accent-soft: rgba(72, 77, 196, 0.09);
   --nori-shell-gradient:
-    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(94, 106, 210, 0.07), transparent 52%),
-    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(124, 92, 255, 0.05), transparent 48%);
+    radial-gradient(ellipse 140% 90% at 0% -10%, rgba(72, 77, 196, 0.1), transparent 52%),
+    radial-gradient(ellipse 100% 80% at 100% 110%, rgba(92, 72, 196, 0.07), transparent 48%);
 
   /* Neutral dark palette — purple only via gradients above */
   --nori-bg: #090909;
@@ -66,16 +66,16 @@
 }
 
 [data-theme="light"] {
-  --nori-cyan: #5e6ad2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
-  --nori-accent: #5e6ad2;
-  --nori-accent-dim: rgba(94, 106, 210, 0.1);
-  --nori-accent-edge: rgba(94, 106, 210, 0.28);
-  --nori-accent-soft: rgba(94, 106, 210, 0.05);
+  --nori-cyan: #454ab8;
+  --nori-cyan-dim: rgba(69, 74, 184, 0.12);
+  --nori-accent: #454ab8;
+  --nori-accent-dim: rgba(69, 74, 184, 0.12);
+  --nori-accent-edge: rgba(69, 74, 184, 0.34);
+  --nori-accent-soft: rgba(69, 74, 184, 0.07);
   --nori-shell-gradient:
-    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(94, 106, 210, 0.05), transparent 50%),
-    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(124, 92, 255, 0.04), transparent 45%);
-  --nori-link: #4f57c7;
+    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(69, 74, 184, 0.07), transparent 50%),
+    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(92, 72, 196, 0.05), transparent 45%);
+  --nori-link: #3f44a8;
   --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
   --nori-surface-raised: #f4f4f6;
@@ -796,7 +796,7 @@ textarea.input:focus {
 .workspace-inspector-resizer:hover::after,
 .workspace-inspector-resizer:focus-visible::after,
 .workspace-chat-layout.inspector-resizing .workspace-inspector-resizer::after {
-  opacity: 0.95;
+  opacity: 1;
 }
 
 .initial-usage {

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -5,11 +5,11 @@
    ========================================================================== */
 
 :root {
-  /* Accent — sparse: edges, focus, active tab underline only */
-  --nori-accent: #5e6ad2;
+  /* Accent — user-overridable via Settings → Accent color (--nori-cyan) */
   --nori-cyan: #5e6ad2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
-  --nori-accent-dim: rgba(94, 106, 210, 0.1);
+  --nori-accent: var(--nori-cyan);
+  --nori-cyan-dim: color-mix(in srgb, var(--nori-cyan) 10%, transparent);
+  --nori-accent-dim: color-mix(in srgb, var(--nori-accent) 10%, transparent);
   --nori-thinking: #8b8b8b;
   --nori-shell-gradient: none;
 
@@ -63,17 +63,11 @@
 
 [data-theme="light"] {
   --nori-cyan: #5e6ad2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.1);
-  --nori-accent: #5e6ad2;
-  --nori-accent-dim: rgba(94, 106, 210, 0.1);
-  --nori-accent-edge: rgba(94, 106, 210, 0.3);
-  --nori-accent-soft: rgba(94, 106, 210, 0.05);
-  --nori-accent-hover: #828fff;
-  --nori-accent-focus: #5e69d1;
-  --nori-shell-gradient:
-    radial-gradient(ellipse 120% 80% at 0% 0%, rgba(94, 106, 210, 0.06), transparent 50%),
-    radial-gradient(ellipse 90% 70% at 100% 100%, rgba(130, 143, 255, 0.04), transparent 45%);
-  --nori-link: #5e6ad2;
+  --nori-accent: var(--nori-cyan);
+  --nori-cyan-dim: color-mix(in srgb, var(--nori-cyan) 10%, transparent);
+  --nori-accent-dim: color-mix(in srgb, var(--nori-accent) 10%, transparent);
+  --nori-shell-gradient: none;
+  --nori-link: var(--nori-accent);
   --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
   --nori-surface-raised: #f4f4f6;
@@ -392,7 +386,7 @@ textarea.input:focus {
 
 .chat-input-area:focus-within {
   border-color: color-mix(in srgb, var(--nori-accent) 30%, var(--nori-border-strong));
-  box-shadow: 0 0 0 1px rgba(94, 106, 210, 0.1);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--nori-accent) 10%, transparent);
 }
 
 .chat-send-btn {
@@ -767,7 +761,7 @@ textarea.input:focus {
 
 .codex-layout .sidebar,
 .sidebar {
-  box-shadow: inset -1px 0 0 rgba(94, 106, 210, 0.28);
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--nori-accent) 28%, transparent);
 }
 
 .codex-layout .sidebar-nav-item.active,
@@ -781,24 +775,24 @@ textarea.input:focus {
 }
 
 .starter-card {
-  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.22);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 22%, transparent);
 }
 
 .inspector-navigation,
 .inspector-navigation.compact {
   border-color: var(--nori-border);
-  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.38);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 38%, transparent);
 }
 
 .inspector-stage {
-  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.28);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 28%, transparent);
 }
 
 .sidebar-resizer::after,
 .workspace-inspector-resizer::after {
   background: radial-gradient(
     ellipse 2px 72px at center var(--resize-highlight-y),
-    rgba(94, 106, 210, 0.75) 0,
+    color-mix(in srgb, var(--nori-accent) 75%, transparent) 0,
     transparent 100%
   );
   opacity: 0.35;
@@ -822,7 +816,7 @@ textarea.input:focus {
   color: var(--nori-accent);
   border: 1px solid var(--nori-border-strong);
   background: var(--nori-control);
-  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.55);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 55%, transparent);
 }
 
 .codex-layout .chat-send-btn {
@@ -839,7 +833,7 @@ textarea.input:focus {
   border: 1px solid var(--nori-border-strong);
   background: var(--nori-control);
   box-shadow:
-    inset 0 1px 0 rgba(94, 106, 210, 0.2),
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 20%, transparent),
     0 14px 38px rgba(0, 0, 0, 0.18);
   backdrop-filter: none;
 }
@@ -847,16 +841,16 @@ textarea.input:focus {
 .codex-layout .chat-input-area:focus-within {
   border-color: color-mix(in srgb, var(--nori-accent) 40%, var(--nori-border-strong));
   box-shadow:
-    inset 0 1px 0 rgba(94, 106, 210, 0.35),
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 35%, transparent),
     0 16px 42px rgba(0, 0, 0, 0.2),
-    0 0 0 1px rgba(94, 106, 210, 0.2);
+    0 0 0 1px color-mix(in srgb, var(--nori-accent) 20%, transparent);
 }
 
 .initial-usage {
   border: 1px solid color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border-strong));
   background: color-mix(in srgb, var(--nori-surface-raised) 92%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(94, 106, 210, 0.42),
+    inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 42%, transparent),
     0 14px 38px rgba(0, 0, 0, 0.2);
   backdrop-filter: none;
 }
@@ -864,13 +858,13 @@ textarea.input:focus {
 .initial-usage-metrics > div {
   border-color: var(--nori-border);
   background: var(--nori-control);
-  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.12);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--nori-accent) 12%, transparent);
 }
 
 .inspector-navigation.compact button.active {
   color: var(--nori-accent);
   background: var(--nori-control-active);
-  box-shadow: inset 0 0 0 1px rgba(94, 106, 210, 0.28);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nori-accent) 28%, transparent);
 }
 
 .codex-layout .inspector-open-tab.active,

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -40,6 +40,7 @@
 
   /* Shell tokens */
   --nori-shell: #0a0a0b;
+  --nori-sidebar-bg: #0c0c0e;
   --nori-topbar: #0a0a0b;
   --nori-statusbar: #101012;
   --nori-control: #16161a;
@@ -79,6 +80,7 @@
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);
   --nori-shell: #f9f9fb;
+  --nori-sidebar-bg: #f4f4f6;
   --nori-topbar: #ffffff;
   --nori-statusbar: #f4f4f6;
   --nori-control: #f4f4f6;
@@ -166,14 +168,39 @@
 
 /* ── Shell layout ──────────────────────────────────────────────────────── */
 
+.codex-layout .sidebar,
 .sidebar {
-  background: var(--nori-shell);
+  background: var(--nori-sidebar-bg);
   backdrop-filter: none;
   border-right: 1px solid var(--nori-border);
 }
 
+[data-theme="light"] .codex-layout .sidebar,
 [data-theme="light"] .sidebar {
-  background: var(--nori-shell);
+  background: var(--nori-sidebar-bg);
+}
+
+.sidebar-footer-nav {
+  border-top: 1px solid var(--nori-border);
+}
+
+.codex-layout .sidebar-workspace-switch {
+  border-radius: var(--nori-radius-sm);
+  background: var(--nori-control);
+  border-color: var(--nori-border);
+}
+
+.codex-layout .sidebar-nav-item.active,
+.codex-layout .sidebar-tab.active,
+.sidebar-nav-item.active {
+  background: var(--nori-control-active);
+  color: var(--nori-text);
+}
+
+.codex-layout .sidebar-nav-item,
+.codex-layout .sidebar-tab,
+.sidebar-nav-item {
+  border-radius: var(--nori-radius-sm);
 }
 
 .top-bar {

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -763,16 +763,45 @@ textarea.input:focus {
   color: var(--nori-text-muted);
 }
 
-/* ── Sparse purple accents (edges & focus only) ──────────────────────────── */
+/* ── Gray base + visible edge accents (rim lines, not fills) ─────────────── */
+
+.codex-layout .sidebar,
+.sidebar {
+  box-shadow: inset -1px 0 0 rgba(94, 106, 210, 0.28);
+}
+
+.codex-layout .sidebar-nav-item.active,
+.codex-layout .sidebar-tab.active {
+  background: var(--nori-control-active);
+  box-shadow: inset 3px 0 0 var(--nori-accent);
+}
+
+.starter-card svg {
+  color: var(--nori-accent);
+}
+
+.starter-card {
+  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.22);
+}
+
+.inspector-navigation,
+.inspector-navigation.compact {
+  border-color: var(--nori-border);
+  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.38);
+}
+
+.inspector-stage {
+  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.28);
+}
 
 .sidebar-resizer::after,
 .workspace-inspector-resizer::after {
   background: radial-gradient(
     ellipse 2px 72px at center var(--resize-highlight-y),
-    color-mix(in srgb, var(--nori-accent) 50%, transparent) 0,
+    rgba(94, 106, 210, 0.75) 0,
     transparent 100%
   );
-  opacity: 0.28;
+  opacity: 0.35;
 }
 
 .sidebar-resizer:hover::after,
@@ -780,68 +809,68 @@ textarea.input:focus {
 .workspace-inspector-resizer:hover::after,
 .workspace-inspector-resizer:focus-visible::after,
 .workspace-chat-layout.inspector-resizing .workspace-inspector-resizer::after {
-  opacity: 0.75;
-}
-
-.goal-island-icon,
-.streaming-cursor,
-.badge-info,
-.spinner,
-.chat-message-role span,
-.chat-turn-rail button:focus-visible i,
-.composer-usage i b,
-.provider-card-mark,
-.cron-job-icon {
-  color: var(--nori-text-secondary);
-  background: var(--nori-control);
+  opacity: 0.9;
 }
 
 .streaming-cursor {
-  background: var(--nori-text-muted);
+  background: var(--nori-accent);
 }
 
-.spinner {
-  border-top-color: var(--nori-text-muted);
-}
-
-.composer-usage i b {
-  background: var(--nori-text-muted);
-}
-
-/* nori-theme .codex-layout rules load before this file — win on conflicts */
+/* nori-theme .codex-layout rules are earlier — these must win */
 
 .codex-layout .chat-welcome .welcome-mark {
-  color: var(--nori-text-secondary);
-  border-color: var(--nori-border);
+  color: var(--nori-accent);
+  border: 1px solid var(--nori-border-strong);
   background: var(--nori-control);
-  box-shadow: none;
+  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.55);
+}
+
+.codex-layout .chat-send-btn {
+  color: var(--nori-primary-fg);
+  background: var(--nori-primary-bg);
+}
+
+.codex-layout .chat-send-btn:hover:not(:disabled) {
+  color: var(--nori-primary-fg);
+  background: var(--nori-primary-hover);
 }
 
 .codex-layout .chat-input-area {
   border: 1px solid var(--nori-border-strong);
   background: var(--nori-control);
-  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(94, 106, 210, 0.2),
+    0 14px 38px rgba(0, 0, 0, 0.18);
   backdrop-filter: none;
 }
 
 .codex-layout .chat-input-area:focus-within {
-  border-color: color-mix(in srgb, var(--nori-accent) 32%, var(--nori-border-strong));
+  border-color: color-mix(in srgb, var(--nori-accent) 40%, var(--nori-border-strong));
   box-shadow:
+    inset 0 1px 0 rgba(94, 106, 210, 0.35),
     0 16px 42px rgba(0, 0, 0, 0.2),
-    0 0 0 1px rgba(94, 106, 210, 0.14);
+    0 0 0 1px rgba(94, 106, 210, 0.2);
 }
 
 .initial-usage {
-  border: 1px solid var(--nori-border-strong);
-  background: color-mix(in srgb, var(--nori-surface-raised) 86%, transparent);
-  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.2);
+  border: 1px solid color-mix(in srgb, var(--nori-accent) 24%, var(--nori-border-strong));
+  background: color-mix(in srgb, var(--nori-surface-raised) 92%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(94, 106, 210, 0.42),
+    0 14px 38px rgba(0, 0, 0, 0.2);
   backdrop-filter: none;
 }
 
 .initial-usage-metrics > div {
   border-color: var(--nori-border);
   background: var(--nori-control);
-  box-shadow: none;
+  box-shadow: inset 0 1px 0 rgba(94, 106, 210, 0.12);
+}
+
+.inspector-navigation.compact button.active {
+  color: var(--nori-accent);
+  background: var(--nori-control-active);
+  box-shadow: inset 0 0 0 1px rgba(94, 106, 210, 0.28);
 }
 
 .codex-layout .inspector-open-tab.active,

--- a/apps/nori-web/src/styles/linear-flat.css
+++ b/apps/nori-web/src/styles/linear-flat.css
@@ -407,7 +407,139 @@ textarea.input:focus {
   box-shadow: none;
 }
 
-/* ── Inspector panels ──────────────────────────────────────────────────── */
+/* ── Sidebar — neutral active states (no accent tint) ──────────────────── */
+
+.sidebar-tab.active,
+.codex-layout .sidebar-tab.active {
+  background: var(--nori-control-active);
+  color: var(--nori-text);
+}
+
+.sidebar-tab.active svg,
+.codex-layout .sidebar-tab.active svg,
+.sidebar-nav-item.active svg,
+.codex-layout .sidebar-nav-item.active svg {
+  color: var(--nori-text);
+}
+
+.sidebar-item.active,
+.codex-layout .sidebar-item.active {
+  border-color: transparent;
+  background: var(--nori-control-hover);
+  color: var(--nori-text);
+}
+
+.codex-layout .sidebar-workspace-switch .sidebar-tab.active {
+  border-color: var(--nori-border-strong);
+  background: var(--nori-control-active);
+  box-shadow: none;
+}
+
+.codex-layout .sidebar-workspace-switch .sidebar-tab.active svg {
+  color: var(--nori-text);
+}
+
+.sidebar-empty svg {
+  color: var(--nori-text-muted);
+}
+
+/* ── Inspector — flat docked panel (no floating island) ────────────────── */
+
+.workspace-inspector,
+.codex-layout .inspector-pane {
+  border-left: none;
+}
+
+.inspector-navigation {
+  border: 1px solid var(--nori-border);
+  border-radius: var(--nori-radius);
+  background: var(--nori-surface);
+  box-shadow: none;
+}
+
+.inspector-navigation.compact {
+  border-radius: var(--nori-radius);
+  box-shadow: none;
+}
+
+.inspector-stage {
+  border: 1px solid var(--nori-border);
+  border-radius: var(--nori-radius);
+  background: var(--nori-surface);
+  box-shadow: none;
+}
+
+.inspector-stage.open {
+  transform: none;
+}
+
+.inspector-overview-open .inspector-tab-list > button:hover {
+  transform: none;
+}
+
+.inspector-nav-icon {
+  border-radius: var(--nori-radius-sm);
+  background: var(--nori-control);
+}
+
+.inspector-tab-list > button:hover .inspector-nav-icon,
+.inspector-tab-list > button.active .inspector-nav-icon {
+  color: var(--nori-text);
+  background: var(--nori-control-hover);
+  transform: none;
+}
+
+.inspector-navigation.compact button:hover,
+.inspector-navigation.compact .inspector-collapse-button:hover {
+  transform: none;
+}
+
+.inspector-navigation.compact button.active {
+  color: var(--nori-text);
+  background: var(--nori-control-active);
+}
+
+.inspector-navigation.compact .inspector-tab-list em {
+  background: var(--nori-control-active);
+  color: var(--nori-text-secondary);
+}
+
+.inspector-pin-button.active {
+  color: var(--nori-text);
+  background: var(--nori-control-hover);
+}
+
+.inspector-activity-icon,
+.inspector-activity-highlight strong,
+.inspector-activity-line.active strong {
+  color: var(--nori-text-secondary);
+}
+
+.inspector-open-tab.active {
+  box-shadow: inset 0 -1px var(--nori-border-strong);
+}
+
+.inspector-tool-menu {
+  border-radius: var(--nori-radius-sm);
+  box-shadow: var(--nori-shadow-popover);
+}
+
+.inspector-collapse-button:hover {
+  transform: none;
+}
+
+/* Auto-hide peek: no border artifact on the edge */
+.workspace-chat-layout .workspace-inspector.inspector-overview-auto-hide:not(.standalone) {
+  transform: translateX(calc(100% - 8px));
+  border: none;
+}
+
+.workspace-chat-layout .workspace-inspector.inspector-overview-auto-hide:not(.standalone):hover,
+.workspace-chat-layout .workspace-inspector.inspector-overview-auto-hide:not(.standalone):focus-within {
+  transform: translateX(0);
+}
+
+/* ── Inspector panels (legacy class names) ───────────────────────────────── */
 
 .inspector-tabs button {
   border-radius: var(--nori-radius-sm);
@@ -415,10 +547,6 @@ textarea.input:focus {
 
 .inspector-tabs button.active {
   box-shadow: none;
-}
-
-.codex-layout .inspector-pane {
-  border-left: 1px solid var(--nori-border);
 }
 
 /* ── Reduce motion on decorative transforms ────────────────────────────── */
@@ -454,10 +582,6 @@ textarea.input:focus {
 
 .inspector-pin-button:hover {
   transform: none;
-}
-
-.workspace-inspector {
-  border-left: 1px solid var(--nori-border);
 }
 
 /* ── File tree ───────────────────────────────────────────────────────────── */

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -7,42 +7,42 @@
 :root {
   /* accent */
   --nori-cyan: #00BCD4;
-  --nori-cyan-dim: rgba(0, 188, 212, 0.15);
+  --nori-cyan-dim: rgba(0, 188, 212, 0.12);
   --nori-thinking: #9be8b0;
 
-  /* backgrounds */
-  --nori-bg: #08080a;
-  --nori-surface: #111114;
-  --nori-surface-raised: #16161a;
-  --nori-surface-hover: #18181c;
-  --nori-bg-elevated: #16161a;
+  /* backgrounds — Linear-inspired neutral palette */
+  --nori-bg: #09090b;
+  --nori-surface: #111113;
+  --nori-surface-raised: #18181b;
+  --nori-surface-hover: #1f1f23;
+  --nori-bg-elevated: #18181b;
 
   /* borders */
-  --nori-border: #1e1e22;
-  --nori-border-active: #00BCD4;
+  --nori-border: #27272a;
+  --nori-border-active: #52525b;
 
   /* text */
-  --nori-text: #e4e4e7;
+  --nori-text: #fafafa;
   --nori-text-secondary: #a1a1aa;
   --nori-text-muted: #71717a;
 
   /* semantic */
   --nori-success: #22c55e;
-  --nori-success-dim: rgba(34, 197, 94, 0.15);
+  --nori-success-dim: rgba(34, 197, 94, 0.12);
   --nori-warning: #f59e0b;
-  --nori-warning-dim: rgba(245, 158, 11, 0.15);
+  --nori-warning-dim: rgba(245, 158, 11, 0.12);
   --nori-danger: #ef4444;
-  --nori-danger-dim: rgba(239, 68, 68, 0.15);
+  --nori-danger-dim: rgba(239, 68, 68, 0.12);
   --nori-purple: #7c3aed;
-  --nori-purple-dim: rgba(124, 58, 237, 0.15);
+  --nori-purple-dim: rgba(124, 58, 237, 0.12);
 
   /* shape */
-  --nori-radius: 8px;
+  --nori-radius: 6px;
   --nori-radius-sm: 4px;
 
   /* typography */
   --nori-font: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', 'Consolas', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', monospace;
-  --nori-font-ui: system-ui, -apple-system, sans-serif;
+  --nori-font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
   --nori-ui-font-scale: 1;
   --nori-ui-control-scale: 1;
   --nori-ui-space-scale: 1;
@@ -1500,55 +1500,58 @@ select.input option {
    Nori Desktop shell refresh
    ========================================================================== */
 :root {
-  --nori-bg: #151515;
-  --nori-surface: #1c1c1c;
-  --nori-surface-raised: #232323;
-  --nori-surface-hover: #292929;
-  --nori-bg-elevated: #232323;
-  --nori-border: #303030;
-  --nori-text: #f2f2f2;
-  --nori-text-secondary: #b7b7b7;
-  --nori-text-muted: #818181;
-  --nori-cyan: #9be8b0;
-  --nori-cyan-dim: rgba(155, 232, 176, 0.10);
-  --nori-border-active: #767676;
-  --nori-radius: 12px;
-  --nori-radius-sm: 8px;
-  --nori-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
-  color-scheme: dark;
-  --nori-shell: #151515;
-  --nori-topbar: #151515;
-  --nori-statusbar: #191919;
-  --nori-control: #202020;
-  --nori-control-hover: #292929;
-  --nori-control-active: #303030;
-  --nori-border-strong: #3a3a3a;
+  /* Linear-inspired design tokens — see linear-flat.css for component overrides */
+  --nori-bg: #09090b;
+  --nori-surface: #111113;
+  --nori-surface-raised: #18181b;
+  --nori-surface-hover: #1f1f23;
+  --nori-bg-elevated: #18181b;
+  --nori-border: #27272a;
+  --nori-border-strong: #3f3f46;
+  --nori-border-active: #52525b;
+  --nori-text: #fafafa;
+  --nori-text-secondary: #a1a1aa;
+  --nori-text-muted: #71717a;
+  --nori-text-subtle: #52525b;
+  --nori-radius: 6px;
+  --nori-radius-sm: 4px;
+  --nori-shadow: none;
+  --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.32);
+  --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
+  --nori-shell: #09090b;
+  --nori-topbar: #09090b;
+  --nori-statusbar: #111113;
+  --nori-control: #18181b;
+  --nori-control-hover: #1f1f23;
+  --nori-control-active: #27272a;
   --nori-font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
+  color-scheme: dark;
 }
 
 [data-theme="light"] {
-  --nori-bg: #eef2f0;
+  --nori-bg: #fafafa;
   --nori-surface: #ffffff;
-  --nori-surface-raised: #f8fbfa;
-  --nori-surface-hover: #e6eeeb;
+  --nori-surface-raised: #f4f4f5;
+  --nori-surface-hover: #f4f4f5;
   --nori-bg-elevated: #ffffff;
-  --nori-border: #c6d1ce;
-  --nori-border-active: #4a9f74;
-  --nori-text: #18231f;
-  --nori-text-secondary: #3f514b;
-  --nori-text-muted: #687a73;
-  --nori-cyan: #267a52;
-  --nori-cyan-dim: rgba(38, 122, 82, 0.14);
-  --nori-thinking: #17633f;
-  --nori-shadow: 0 18px 50px rgba(28, 53, 41, 0.16);
+  --nori-border: #e4e4e7;
+  --nori-border-strong: #d4d4d8;
+  --nori-border-active: #a1a1aa;
+  --nori-text: #18181b;
+  --nori-text-secondary: #52525b;
+  --nori-text-muted: #71717a;
+  --nori-text-subtle: #a1a1aa;
+  --nori-shadow: none;
+  --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+  --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);
   color-scheme: light;
-  --nori-shell: #f3f6f4;
+  --nori-shell: #fafafa;
   --nori-topbar: #ffffff;
-  --nori-statusbar: #edf2ef;
-  --nori-control: #f8fbfa;
-  --nori-control-hover: #e8f0ed;
-  --nori-control-active: #dce8e3;
-  --nori-border-strong: #aebfba;
+  --nori-statusbar: #f4f4f5;
+  --nori-control: #f4f4f5;
+  --nori-control-hover: #e4e4e7;
+  --nori-control-active: #d4d4d8;
+  --nori-border-strong: #d4d4d8;
 }
 
 body {

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -5,26 +5,26 @@
 /* ── Variables ─────────────────────────────────────────────────────────── */
 
 :root {
-  /* accent */
-  --nori-cyan: #00BCD4;
-  --nori-cyan-dim: rgba(0, 188, 212, 0.12);
-  --nori-thinking: #9be8b0;
+  /* accent — Linear indigo */
+  --nori-cyan: #5E6AD2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
+  --nori-thinking: #8b8d98;
 
-  /* backgrounds — Linear-inspired neutral palette */
-  --nori-bg: #09090b;
-  --nori-surface: #111113;
-  --nori-surface-raised: #18181b;
-  --nori-surface-hover: #1f1f23;
-  --nori-bg-elevated: #18181b;
+  /* backgrounds — Linear cool dark palette */
+  --nori-bg: #0a0a0b;
+  --nori-surface: #101012;
+  --nori-surface-raised: #16161a;
+  --nori-surface-hover: #1c1c21;
+  --nori-bg-elevated: #16161a;
 
   /* borders */
-  --nori-border: #27272a;
+  --nori-border: #2c2c30;
   --nori-border-active: #52525b;
 
   /* text */
-  --nori-text: #fafafa;
-  --nori-text-secondary: #a1a1aa;
-  --nori-text-muted: #71717a;
+  --nori-text: #f0f0f3;
+  --nori-text-secondary: #8b8d98;
+  --nori-text-muted: #5c5c65;
 
   /* semantic */
   --nori-success: #22c55e;
@@ -1500,58 +1500,62 @@ select.input option {
    Nori Desktop shell refresh
    ========================================================================== */
 :root {
-  /* Linear-inspired design tokens — see linear-flat.css for component overrides */
-  --nori-bg: #09090b;
-  --nori-surface: #111113;
-  --nori-surface-raised: #18181b;
-  --nori-surface-hover: #1f1f23;
-  --nori-bg-elevated: #18181b;
-  --nori-border: #27272a;
-  --nori-border-strong: #3f3f46;
+  /* Linear design tokens — see linear-flat.css for component overrides */
+  --nori-bg: #0a0a0b;
+  --nori-surface: #101012;
+  --nori-surface-raised: #16161a;
+  --nori-surface-hover: #1c1c21;
+  --nori-bg-elevated: #16161a;
+  --nori-border: #2c2c30;
+  --nori-border-strong: #3a3a40;
   --nori-border-active: #52525b;
-  --nori-text: #fafafa;
-  --nori-text-secondary: #a1a1aa;
-  --nori-text-muted: #71717a;
-  --nori-text-subtle: #52525b;
+  --nori-text: #f0f0f3;
+  --nori-text-secondary: #8b8d98;
+  --nori-text-muted: #5c5c65;
+  --nori-text-subtle: #45454d;
+  --nori-cyan: #5E6AD2;
+  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
   --nori-radius: 6px;
   --nori-radius-sm: 4px;
   --nori-shadow: none;
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.32);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
-  --nori-shell: #09090b;
-  --nori-topbar: #09090b;
-  --nori-statusbar: #111113;
-  --nori-control: #18181b;
-  --nori-control-hover: #1f1f23;
-  --nori-control-active: #27272a;
+  --nori-shell: #0a0a0b;
+  --nori-topbar: #0a0a0b;
+  --nori-statusbar: #101012;
+  --nori-control: #16161a;
+  --nori-control-hover: #1c1c21;
+  --nori-control-active: #242429;
   --nori-font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
   color-scheme: dark;
 }
 
 [data-theme="light"] {
-  --nori-bg: #fafafa;
+  --nori-bg: #f9f9fb;
   --nori-surface: #ffffff;
-  --nori-surface-raised: #f4f4f5;
-  --nori-surface-hover: #f4f4f5;
+  --nori-surface-raised: #f4f4f6;
+  --nori-surface-hover: #ececf0;
   --nori-bg-elevated: #ffffff;
-  --nori-border: #e4e4e7;
-  --nori-border-strong: #d4d4d8;
-  --nori-border-active: #a1a1aa;
-  --nori-text: #18181b;
-  --nori-text-secondary: #52525b;
-  --nori-text-muted: #71717a;
-  --nori-text-subtle: #a1a1aa;
+  --nori-border: #e0e0e6;
+  --nori-border-strong: #cacad4;
+  --nori-border-active: #8b8d98;
+  --nori-text: #1a1a1e;
+  --nori-text-secondary: #5c5c65;
+  --nori-text-muted: #8b8d98;
+  --nori-text-subtle: #a8a8b3;
+  --nori-cyan: #4f57c7;
+  --nori-cyan-dim: rgba(79, 87, 199, 0.14);
   --nori-shadow: none;
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);
   color-scheme: light;
-  --nori-shell: #fafafa;
+  --nori-shell: #f9f9fb;
   --nori-topbar: #ffffff;
-  --nori-statusbar: #f4f4f5;
-  --nori-control: #f4f4f5;
-  --nori-control-hover: #e4e4e7;
-  --nori-control-active: #d4d4d8;
-  --nori-border-strong: #d4d4d8;
+  --nori-statusbar: #f4f4f6;
+  --nori-control: #f4f4f6;
+  --nori-control-hover: #ececf0;
+  --nori-control-active: #e0e0e6;
+  --nori-border-strong: #cacad4;
 }
 
 body {

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -1582,12 +1582,13 @@ kbd {
   width: 64px;
   min-width: 64px;
   height: 100vh;
-  background: rgba(17, 20, 25, 0.94);
-  backdrop-filter: blur(18px);
+  background: var(--nori-shell);
+  border-right: 1px solid var(--nori-border);
+  backdrop-filter: none;
   transition: width .22s cubic-bezier(.2,.8,.2,1), min-width .22s cubic-bezier(.2,.8,.2,1);
   z-index: 10;
 }
-[data-theme="light"] .sidebar { background: rgba(251, 252, 252, 0.94); }
+[data-theme="light"] .sidebar { background: var(--nori-shell); }
 .sidebar:hover { width: 64px; }
 .sidebar.expanded { width: 272px; min-width: 272px; }
 .sidebar-brand {
@@ -1642,7 +1643,7 @@ kbd {
   white-space: nowrap;
 }
 .sidebar.expanded .sidebar-tab { width: 100%; }
-.sidebar-tab.active { background: var(--nori-cyan-dim); color: var(--nori-cyan); }
+.sidebar-tab.active { background: var(--nori-control-active); color: var(--nori-text); }
 .sidebar-tab-label { display: none; opacity: 0; transform: translateX(-4px); transition: .15s ease; font-size: calc(12px * var(--nori-ui-font-scale)); font-weight: 600; }
 .sidebar.expanded .sidebar-tab-label { display: inline; opacity: 1; transform: none; }
 .sidebar-content { display: block; min-height: 0; padding: 5px 0 10px; opacity: 0; pointer-events: none; transition: opacity .12s ease; }
@@ -2058,8 +2059,8 @@ kbd {
 .codex-layout .sidebar {
   width: 64px;
   min-width: 64px;
-  background: #1d1d1d;
-  border-right-color: #2b2b2b;
+  background: var(--nori-shell);
+  border-right: 1px solid var(--nori-border);
   backdrop-filter: none;
 }
 .codex-layout .sidebar.expanded {
@@ -2088,7 +2089,7 @@ kbd {
   height: 6px;
   border: 1.5px solid var(--nori-control);
   border-radius: 50%;
-  background: var(--nori-cyan);
+  background: var(--nori-text-muted);
 }
 .sidebar-brand-copy {
   flex: 1;
@@ -2169,7 +2170,11 @@ kbd {
   color: var(--nori-text);
   background: var(--nori-control-active);
 }
-.sidebar-nav-item.active svg { color: var(--nori-cyan); }
+.sidebar-nav-item.active svg,
+.codex-layout .sidebar-tab.active svg,
+.codex-layout .sidebar-nav-item.active svg {
+  color: var(--nori-text);
+}
 
 .sidebar-section-label {
   display: flex;
@@ -2200,7 +2205,6 @@ kbd {
 .codex-layout .sidebar.expanded .sidebar-tab { width: 100%; }
 .codex-layout .sidebar-tab:hover { color: var(--nori-text); background: var(--nori-control-hover); }
 .codex-layout .sidebar-tab.active { color: var(--nori-text); background: var(--nori-control-active); }
-.codex-layout .sidebar-tab.active svg { color: var(--nori-cyan); }
 .codex-layout .sidebar-workspace-switch {
   display: grid;
   width: 44px;
@@ -2230,9 +2234,9 @@ kbd {
 }
 .codex-layout .sidebar.expanded .sidebar-workspace-switch .sidebar-tab { width: 100%; }
 .codex-layout .sidebar-workspace-switch .sidebar-tab.active {
-  border-color: color-mix(in srgb, var(--nori-border-strong) 82%, transparent);
-  background: var(--nori-control-active);
-  box-shadow: 0 1px 3px rgba(0,0,0,.16), inset 0 1px rgba(255,255,255,.04);
+  border-color: var(--nori-border-strong);
+  background: var(--nori-surface-raised);
+  box-shadow: none;
 }
 .codex-layout .sidebar-workspace-switch .sidebar-tab.active svg { color: var(--nori-text); }
 
@@ -3463,9 +3467,9 @@ kbd {
 .workspace-inspector-resizer::after {
   position: absolute;
   inset: 0;
-  background: radial-gradient(ellipse 3px 82px at center var(--resize-highlight-y), color-mix(in srgb, var(--nori-cyan) 72%, transparent) 0, color-mix(in srgb, var(--nori-cyan) 48%, transparent) 32%, transparent 100%);
+  background: radial-gradient(ellipse 2px 72px at center var(--resize-highlight-y), color-mix(in srgb, var(--nori-text-muted) 55%, transparent) 0, transparent 100%);
   content: '';
-  opacity: .2;
+  opacity: .35;
   transition: opacity 140ms ease;
 }
 .sidebar-resizer:hover::after,

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -5,26 +5,26 @@
 /* ── Variables ─────────────────────────────────────────────────────────── */
 
 :root {
-  /* accent — Linear indigo */
-  --nori-cyan: #5E6AD2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
-  --nori-thinking: #8b8d98;
+  /* accent — neutral chrome gray */
+  --nori-cyan: #8b8b8b;
+  --nori-cyan-dim: rgba(255, 255, 255, 0.06);
+  --nori-thinking: #8b8b8b;
 
-  /* backgrounds — Linear cool dark palette */
-  --nori-bg: #0a0a0b;
-  --nori-surface: #101012;
-  --nori-surface-raised: #16161a;
-  --nori-surface-hover: #1c1c21;
-  --nori-bg-elevated: #16161a;
+  /* backgrounds — neutral dark palette */
+  --nori-bg: #090909;
+  --nori-surface: #0f0f0f;
+  --nori-surface-raised: #141414;
+  --nori-surface-hover: #1a1a1a;
+  --nori-bg-elevated: #141414;
 
   /* borders */
-  --nori-border: #2c2c30;
-  --nori-border-active: #52525b;
+  --nori-border: #262626;
+  --nori-border-active: #525252;
 
   /* text */
-  --nori-text: #f0f0f3;
-  --nori-text-secondary: #8b8d98;
-  --nori-text-muted: #5c5c65;
+  --nori-text: #ededed;
+  --nori-text-secondary: #8b8b8b;
+  --nori-text-muted: #5c5c5c;
 
   /* semantic */
   --nori-success: #22c55e;
@@ -1501,31 +1501,31 @@ select.input option {
    ========================================================================== */
 :root {
   /* Linear design tokens — see linear-flat.css for component overrides */
-  --nori-bg: #0a0a0b;
-  --nori-surface: #101012;
-  --nori-surface-raised: #16161a;
-  --nori-surface-hover: #1c1c21;
-  --nori-bg-elevated: #16161a;
-  --nori-border: #2c2c30;
-  --nori-border-strong: #3a3a40;
-  --nori-border-active: #52525b;
-  --nori-text: #f0f0f3;
-  --nori-text-secondary: #8b8d98;
-  --nori-text-muted: #5c5c65;
-  --nori-text-subtle: #45454d;
-  --nori-cyan: #5E6AD2;
-  --nori-cyan-dim: rgba(94, 106, 210, 0.18);
+  --nori-bg: #090909;
+  --nori-surface: #0f0f0f;
+  --nori-surface-raised: #141414;
+  --nori-surface-hover: #1a1a1a;
+  --nori-bg-elevated: #141414;
+  --nori-border: #262626;
+  --nori-border-strong: #333333;
+  --nori-border-active: #525252;
+  --nori-text: #ededed;
+  --nori-text-secondary: #8b8b8b;
+  --nori-text-muted: #5c5c5c;
+  --nori-text-subtle: #454545;
+  --nori-cyan: #8b8b8b;
+  --nori-cyan-dim: rgba(255, 255, 255, 0.06);
   --nori-radius: 6px;
   --nori-radius-sm: 4px;
   --nori-shadow: none;
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.32);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.24);
-  --nori-shell: #0a0a0b;
-  --nori-topbar: #0a0a0b;
-  --nori-statusbar: #101012;
-  --nori-control: #16161a;
-  --nori-control-hover: #1c1c21;
-  --nori-control-active: #242429;
+  --nori-shell: #090909;
+  --nori-topbar: #090909;
+  --nori-statusbar: #0f0f0f;
+  --nori-control: #141414;
+  --nori-control-hover: #1a1a1a;
+  --nori-control-active: #222222;
   --nori-font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
   color-scheme: dark;
 }
@@ -1543,8 +1543,8 @@ select.input option {
   --nori-text-secondary: #5c5c65;
   --nori-text-muted: #8b8d98;
   --nori-text-subtle: #a8a8b3;
-  --nori-cyan: #4f57c7;
-  --nori-cyan-dim: rgba(79, 87, 199, 0.14);
+  --nori-cyan: #5c5c5c;
+  --nori-cyan-dim: rgba(0, 0, 0, 0.06);
   --nori-shadow: none;
   --nori-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
   --nori-shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.06);

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#484dc4';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#6b72d6', '#8b8b8b', '#8b8d98']);
+export const DEFAULT_ACCENT = '#5e6ad2';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#4f57c7', '#484dc4', '#6b72d6', '#8b8b8b', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#5E6AD2';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0']);
+export const DEFAULT_ACCENT = '#8b8b8b';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#5e6ad2';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#4f57c7', '#484dc4', '#6b72d6', '#8b8b8b', '#8b8d98']);
+export const DEFAULT_ACCENT = '#8b7cf8';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#4f57c7', '#484dc4', '#5e6ad2', '#6b72d6', '#8b8b8b', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#6b72d6';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#8b8b8b', '#8b8d98']);
+export const DEFAULT_ACCENT = '#484dc4';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#6b72d6', '#8b8b8b', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -55,8 +55,13 @@ export function applyThemeColor(color: string, persist = true): void {
     try { localStorage.setItem(THEME_KEY, color); } catch { /* no-op */ }
   }
   document.documentElement.style.setProperty('--nori-cyan', color);
+  document.documentElement.style.setProperty('--nori-accent', color);
   document.documentElement.style.setProperty(
     '--nori-cyan-dim',
+    color + (document.documentElement.dataset.theme === 'light' ? '19' : '26'),
+  );
+  document.documentElement.style.setProperty(
+    '--nori-accent-dim',
     color + (document.documentElement.dataset.theme === 'light' ? '19' : '26'),
   );
 }

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#9BE8B0';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7']);
+export const DEFAULT_ACCENT = '#5E6AD2';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 
@@ -55,7 +55,6 @@ export function applyThemeColor(color: string, persist = true): void {
     try { localStorage.setItem(THEME_KEY, color); } catch { /* no-op */ }
   }
   document.documentElement.style.setProperty('--nori-cyan', color);
-  document.documentElement.style.setProperty('--nori-border-active', color);
   document.documentElement.style.setProperty(
     '--nori-cyan-dim',
     color + (document.documentElement.dataset.theme === 'light' ? '19' : '26'),

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#8b8b8b';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#8b8d98']);
+export const DEFAULT_ACCENT = '#6b72d6';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#5e6ad2', '#4f57c7', '#8b8b8b', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 

--- a/apps/nori-web/src/theme.ts
+++ b/apps/nori-web/src/theme.ts
@@ -3,8 +3,8 @@ export type ThemeMode = 'dark' | 'light';
 const THEME_KEY = 'nori-theme-color';
 const THEME_MODE_KEY = 'nori-theme';
 const UI_SCALE_KEY = 'nori-ui-scale';
-export const DEFAULT_ACCENT = '#8b7cf8';
-const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#4f57c7', '#484dc4', '#5e6ad2', '#6b72d6', '#8b8b8b', '#8b8d98']);
+export const DEFAULT_ACCENT = '#5e6ad2';
+const LEGACY_ACCENTS = new Set(['#00bcd4', '#6dd6c7', '#9be8b0', '#4f57c7', '#484dc4', '#6b72d6', '#8b7cf8', '#8b8b8b', '#8b8d98']);
 
 export type UiScale = 'compact' | 'default' | 'large';
 


### PR DESCRIPTION
## 关联 Issue

Closes [WORK-7](https://linear.app/sudden/issue/WORK-7/ui-linear风格)（Linear 风格 UI 改造）

## 变更摘要

在**中性灰底色**上适度加入 Linear 风格的紫色层次：

* 全局背景：极淡紫径向渐变（`--nori-shell-gradient`）
* 边缘高亮：侧栏右边框、顶栏底边、Inspector 面板顶边内发光
* 交互态：导航选中、输入框 focus、拖拽条 hover 带淡紫描边/光晕
* Accent token：`#6b72d6`（仅用于边缘与高亮，不做大面积填充）

## 验证

* `pnpm -C apps/nori-web build` 通过
* 截图见 PR / artifact：`nori-web-linear-neutral-1440x900.png`

Linear Issue: [WORK-7](https://linear.app/sudden/issue/WORK-7/ui-linear%E9%A3%8E%E6%A0%BC)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />