### PR TITLE
feat(nori-web): add expandable tool call details in chat work process

### DIFF
--- a/.changeset/expandable-tool-call-details.md
+++ b/.changeset/expandable-tool-call-details.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/nori-code": patch
+---
+
+Add expandable tool call details in the web chat work process: view inputs, diffs for edits and writes, command output, and failure messages by expanding a tool row.

--- a/apps/nori-web/scripts/capture-tool-call-screenshots.mjs
+++ b/apps/nori-web/scripts/capture-tool-call-screenshots.mjs
@@ -1,0 +1,47 @@
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const outDir = '/opt/cursor/artifacts/screenshots';
+const url = 'http://127.0.0.1:5173/?mock=tool-call-detail';
+
+async function main() {
+  await mkdir(outDir, { recursive: true });
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage({ viewport: { width: 1180, height: 900 } });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.expandable-tool-call', { timeout: 15000 });
+  await page.waitForTimeout(400);
+
+  const workProcess = page.locator('.chat-work-process');
+  await workProcess.screenshot({
+    path: resolve(outDir, 'tool-call-edit-browser-work-process.png'),
+  });
+
+  const editTool = page.locator('.expandable-tool-call.tool-edit');
+  await editTool.screenshot({
+    path: resolve(outDir, 'tool-call-edit-expanded.png'),
+  });
+
+  const browserTool = page.locator('.expandable-tool-call.tool-browser');
+  await browserTool.screenshot({
+    path: resolve(outDir, 'tool-call-browser-expanded.png'),
+  });
+
+  await page.screenshot({
+    path: resolve(outDir, 'tool-call-edit-browser-full.png'),
+    fullPage: true,
+  });
+
+  await browser.close();
+  console.log('Saved screenshots to', outDir);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/nori-web/scripts/verify-and-capture-tool-screenshots.mjs
+++ b/apps/nori-web/scripts/verify-and-capture-tool-screenshots.mjs
@@ -1,0 +1,60 @@
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const outDir = '/opt/cursor/artifacts/screenshots';
+const url = 'http://127.0.0.1:5173/?mock=tool-call-detail';
+
+async function main() {
+  await mkdir(outDir, { recursive: true });
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage({ viewport: { width: 1180, height: 900 } });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.expandable-tool-call.tool-edit', { timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  const editText = await page.locator('.expandable-tool-call.tool-edit').innerText();
+  const hasPlaceholder = editText.includes('[original line');
+  const hasRealDiff = editText.includes('-const summary') || editText.includes('+const failed');
+
+  await writeFile(
+    resolve(outDir, 'tool-call-edit-text-snapshot.txt'),
+    editText,
+    'utf8',
+  );
+
+  const editTool = page.locator('.expandable-tool-call.tool-edit');
+  await editTool.screenshot({
+    path: resolve(outDir, 'tool-call-edit-fixed-v2.png'),
+  });
+
+  const browserTool = page.locator('.expandable-tool-call.tool-browser');
+  await browserTool.screenshot({
+    path: resolve(outDir, 'tool-call-browser-fixed-v2.png'),
+  });
+
+  await page.locator('.chat-work-process').screenshot({
+    path: resolve(outDir, 'tool-call-work-process-fixed-v2.png'),
+  });
+
+  await browser.close();
+
+  console.log(JSON.stringify({
+    hasPlaceholder,
+    hasRealDiff,
+    preview: editText.slice(0, 500),
+  }, null, 2));
+
+  if (hasPlaceholder) {
+    console.error('ERROR: placeholder text still visible in Edit tool panel');
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/nori-web/src/components/ChatView.tsx
+++ b/apps/nori-web/src/components/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ClipboardEvent, type KeyboardEvent, type UIEvent } from 'react';
 import { api, type ApprovalRequest, type McpElicitationRequest, type McpElicitationResponse, type ModelCatalogItem, type PromptAttachment, type PromptExecutionOptions, type QuestionAnswer, type QuestionRequest, type Session, type SessionAgentConfig, type SessionRealtimeStatus, type TokenUsage } from '../api/client';
-import type { ChatMessage, QueuedPrompt, TodoItem, ToolCall, WorkBlock } from '../hooks/useChatMessages';
+import type { ChatMessage, QueuedPrompt, TodoItem, ToolCall, WorkBlock, CodeChange } from '../hooks/useChatMessages';
 import { useBrowserPermissions } from '../hooks/useBrowser';
 import { useI18n } from '../i18n';
 import { chatSlashCommandSuggestions, resolveChatSlashCommand, type ChatSlashCommand, type ChatSlashCommandName } from '../utils/chat-slash-commands';
@@ -54,6 +54,7 @@ export interface ChatViewProps {
   onResolveMcpElicitation?: (elicitationId: string, response: McpElicitationResponse) => void | Promise<void>;
   queuedPrompts?: QueuedPrompt[];
   todos?: TodoItem[];
+  codeChanges?: CodeChange[];
   onCancelQueuedPrompt?: (promptId: string) => void | Promise<void>;
   draftAgentConfig?: SessionAgentConfig;
   rewindLimit?: number;
@@ -181,7 +182,7 @@ function ComposerSettingPicker({ id, label, ariaLabel, value, choices, open, dis
 }
 
 export function ChatView(props: ChatViewProps) {
-  const { session, allSessions = [], messages, messagesLoading = false, streaming, thinking, workBlocks = [], isStreaming, sessionStatus, compacting = false, models, modelsLoading, modelError, onSendMessage, onAbort, onRefreshModels, onModelChange, onThinkingChange, onPermissionChange, onTaskModeChange, onRunSlashCommand, onMainWriteChange, pendingApprovals = [], onResolveApproval, pendingQuestions = [], onResolveQuestion, onDismissQuestion, pendingMcpElicitations = [], onResolveMcpElicitation, queuedPrompts = [], onCancelQueuedPrompt, draftAgentConfig, rewindLimit = 10, onRewind } = props;
+  const { session, allSessions = [], messages, messagesLoading = false, streaming, thinking, workBlocks = [], isStreaming, sessionStatus, compacting = false, models, modelsLoading, modelError, onSendMessage, onAbort, onRefreshModels, onModelChange, onThinkingChange, onPermissionChange, onTaskModeChange, onRunSlashCommand, onMainWriteChange, pendingApprovals = [], onResolveApproval, pendingQuestions = [], onResolveQuestion, onDismissQuestion, pendingMcpElicitations = [], onResolveMcpElicitation, queuedPrompts = [], codeChanges = [], onCancelQueuedPrompt, draftAgentConfig, rewindLimit = 10, onRewind } = props;
   const { tr } = useI18n();
   const browserPermissions = useBrowserPermissions();
   const [input, setInput] = useState('');
@@ -778,9 +779,9 @@ export function ChatView(props: ChatViewProps) {
   return <section className="chat-view" aria-label={tr('Conversation', '对话')}>
     <div className="chat-messages-shell">
     <div className="chat-messages" ref={messagesScrollRef} onScroll={handleMessagesScroll}>
-      {messagesLoading ? <div className="chat-history-loading" role="status"><span className="spinner"/><strong>{tr('Loading conversation…', '正在加载会话…')}</strong></div> : messages.length === 0 ? <div className="chat-welcome"><div className="welcome-mark"><Icon name="sparkles" size={27}/></div><span className="eyebrow">{tr('Your thoughtful coding partner', '你的智能编程伙伴')}</span><h2>{session ? tr('What should we make better?', '我们要改进什么？') : tr('What would you like to work on?', '你想从哪里开始？')}</h2><p>{session ? tr('Ask Nori to inspect code, plan a feature, fix a bug, or validate an API integration.', '让 Nori 检查代码、规划功能、修复缺陷或验证 API 集成。') : tr('Choose a project folder to start a new task, or open an existing conversation from the sidebar. You can also type below now.', '选择一个项目文件夹开始新任务，或从左侧打开已有对话。你也可以直接在下方输入。')}</p><UsageOverview sessions={allSessions} models={models}/><div className="starter-grid">{STARTERS.map(item => <button key={item.title} className="starter-card" onClick={() => void handleSend(tr(item.prompt, item.promptZh))}><Icon name="sparkles" size={16}/><span><strong>{tr(item.title, item.titleZh)}</strong><small>{tr(item.prompt, item.promptZh)}</small></span></button>)}</div></div> : presentedMessages.map(({ message, workStartedAt }, index) => <MessageBubble key={message.id} message={message} workStartedAt={workStartedAt} rewindCount={rewindCounts.get(message.id)} onRewind={handleRewind} approvalRequests={pendingApprovals} live={isStreaming && index === presentedMessages.length - 1 && message.role === 'assistant' ? { streaming, thinking, workBlocks, stopping, onAbort: handleAbort } : undefined}/>) }
+      {messagesLoading ? <div className="chat-history-loading" role="status"><span className="spinner"/><strong>{tr('Loading conversation…', '正在加载会话…')}</strong></div> : messages.length === 0 ? <div className="chat-welcome"><div className="welcome-mark"><Icon name="sparkles" size={27}/></div><span className="eyebrow">{tr('Your thoughtful coding partner', '你的智能编程伙伴')}</span><h2>{session ? tr('What should we make better?', '我们要改进什么？') : tr('What would you like to work on?', '你想从哪里开始？')}</h2><p>{session ? tr('Ask Nori to inspect code, plan a feature, fix a bug, or validate an API integration.', '让 Nori 检查代码、规划功能、修复缺陷或验证 API 集成。') : tr('Choose a project folder to start a new task, or open an existing conversation from the sidebar. You can also type below now.', '选择一个项目文件夹开始新任务，或从左侧打开已有对话。你也可以直接在下方输入。')}</p><UsageOverview sessions={allSessions} models={models}/><div className="starter-grid">{STARTERS.map(item => <button key={item.title} className="starter-card" onClick={() => void handleSend(tr(item.prompt, item.promptZh))}><Icon name="sparkles" size={16}/><span><strong>{tr(item.title, item.titleZh)}</strong><small>{tr(item.prompt, item.promptZh)}</small></span></button>)}</div></div> : presentedMessages.map(({ message, workStartedAt }, index) => <MessageBubble key={message.id} message={message} workStartedAt={workStartedAt} rewindCount={rewindCounts.get(message.id)} onRewind={handleRewind} approvalRequests={pendingApprovals} codeChanges={codeChanges} live={isStreaming && index === presentedMessages.length - 1 && message.role === 'assistant' ? { streaming, thinking, workBlocks, stopping, onAbort: handleAbort } : undefined}/>) }
 
-      {isStreaming && !streamingContinuesAssistant && <div className="chat-message chat-message-assistant chat-message-streaming"><div className="message-body"><div className="chat-message-role">Nori <span>{pendingApprovals.length > 0 || browserPermissions.pending.length > 0 ? tr('waiting for permission', '等待授权') : tr('working', '工作中')}</span></div>{standaloneLiveBlocks.length > 0 ? <LiveWorkStream blocks={standaloneLiveBlocks} activeProgressId={standaloneLiveProgressId} startedAt={latestUserStartedAt} approvalRequests={pendingApprovals}/> : <div className="chat-message-content"><span className="thinking-label">{tr('Waiting for model output…', '等待模型输出…')}</span><span className="streaming-cursor"/></div>}{streaming && <div className="message-token-usage">{tr('Live output', '实时输出')} ~{formatTokens(estimateStreamingTokens(streaming))} tokens</div>}<button className="chat-abort-btn" onClick={() => void handleAbort()} disabled={stopping}><Icon name="stop" size={13}/> {stopping ? tr('Stopping…', '正在停止…') : tr('Stop response', '停止回复')}</button></div></div>}
+      {isStreaming && !streamingContinuesAssistant && <div className="chat-message chat-message-assistant chat-message-streaming"><div className="message-body"><div className="chat-message-role">Nori <span>{pendingApprovals.length > 0 || browserPermissions.pending.length > 0 ? tr('waiting for permission', '等待授权') : tr('working', '工作中')}</span></div>{standaloneLiveBlocks.length > 0 ? <LiveWorkStream blocks={standaloneLiveBlocks} activeProgressId={standaloneLiveProgressId} startedAt={latestUserStartedAt} approvalRequests={pendingApprovals} codeChanges={codeChanges}/> : <div className="chat-message-content"><span className="thinking-label">{tr('Waiting for model output…', '等待模型输出…')}</span><span className="streaming-cursor"/></div>}{streaming && <div className="message-token-usage">{tr('Live output', '实时输出')} ~{formatTokens(estimateStreamingTokens(streaming))} tokens</div>}<button className="chat-abort-btn" onClick={() => void handleAbort()} disabled={stopping}><Icon name="stop" size={13}/> {stopping ? tr('Stopping…', '正在停止…') : tr('Stop response', '停止回复')}</button></div></div>}
       <div ref={messagesEndRef}/>
     </div>
     {turnPreviews.length > 0 && <nav className="chat-turn-rail" style={{ height: `${Math.min(360, Math.max(54, turnPreviews.length * 14))}px` }} aria-label={tr('Conversation turns', '对话轮次')} onPointerMove={event => {
@@ -898,7 +899,7 @@ function formatElapsedDuration(durationMs: number): string {
   return `${hours}h ${String(minutes).padStart(2, '0')}m ${String(seconds).padStart(2, '0')}s`;
 }
 
-function MessageBubble({ message, workStartedAt, rewindCount, onRewind, approvalRequests = [], live }: { message: ChatMessage; workStartedAt?: number; rewindCount?: number; onRewind?: (count: number) => void | Promise<void>; approvalRequests?: ApprovalRequest[]; live?: LiveAssistantContinuation }) {
+function MessageBubble({ message, workStartedAt, rewindCount, onRewind, approvalRequests = [], codeChanges = [], live }: { message: ChatMessage; workStartedAt?: number; rewindCount?: number; onRewind?: (count: number) => void | Promise<void>; approvalRequests?: ApprovalRequest[]; codeChanges?: CodeChange[]; live?: LiveAssistantContinuation }) {
   const { tr } = useI18n();
   const isUser = message.role === 'user';
   const isSystem = message.role === 'system';
@@ -936,10 +937,10 @@ function MessageBubble({ message, workStartedAt, rewindCount, onRewind, approval
     }} title={tr('Rewind to before this prompt', '回溯到此提问之前')}><Icon name="refresh" size={12}/>{tr('Rewind', '回溯')}</button>}</div>}
       {live !== undefined
         ? hasLiveTranscript
-          ? <LiveWorkStream blocks={liveTranscriptBlocks} activeProgressId={liveProgressId} startedAt={workStartedAt} approvalRequests={approvalRequests}/>
+          ? <LiveWorkStream blocks={liveTranscriptBlocks} activeProgressId={liveProgressId} startedAt={workStartedAt} approvalRequests={approvalRequests} codeChanges={codeChanges}/>
           : null
         : hasWork
-          ? <WorkProcess blocks={storedBlocks} startedAt={workStartedAt} durationMs={workDurationMs} approvalRequests={approvalRequests}/>
+          ? <WorkProcess blocks={storedBlocks} startedAt={workStartedAt} durationMs={workDurationMs} approvalRequests={approvalRequests} codeChanges={codeChanges}/>
           : null}
       {message.images && message.images.length > 0 && <div className="chat-message-images">{message.images.map((image, index) => <img key={`${image.src.slice(0, 80)}-${String(index)}`} src={image.src} alt={image.alt} loading="lazy" />)}</div>}
       {(text || (live && !hasWork)) && <div className="chat-message-content">{text ? (isUser || isSystem ? text : <MarkdownView content={text} />) : <span className="thinking-label">{tr('Waiting for model output…', '等待模型输出…')}</span>}{live && !hasWork && <span className="streaming-cursor"/>}</div>}{message.usage && <TokenUsageLine usage={message.usage} />}{live?.streaming && <div className="message-token-usage">{tr('Live output', '实时输出')} ~{formatTokens(estimateStreamingTokens(live.streaming))} tokens</div>}{live && <button className="chat-abort-btn" onClick={() => void live.onAbort()} disabled={live.stopping}><Icon name="stop" size={13}/> {live.stopping ? tr('Stopping…', '正在停止…') : tr('Stop response', '停止回复')}</button>}{message.createdAt && <time className="chat-message-time">{new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>}
@@ -947,7 +948,7 @@ function MessageBubble({ message, workStartedAt, rewindCount, onRewind, approval
   </article>;
 }
 
-function WorkProcess({ blocks, live = false, activeProgressId, startedAt, durationMs, approvalRequests = [] }: { blocks: WorkBlock[]; live?: boolean; activeProgressId?: string; startedAt?: number; durationMs?: number; approvalRequests?: ApprovalRequest[] }) {
+function WorkProcess({ blocks, live = false, activeProgressId, startedAt, durationMs, approvalRequests = [], codeChanges = [] }: { blocks: WorkBlock[]; live?: boolean; activeProgressId?: string; startedAt?: number; durationMs?: number; approvalRequests?: ApprovalRequest[]; codeChanges?: CodeChange[] }) {
   const { tr } = useI18n();
   const [open, setOpen] = useState(live);
   const fallbackStartedAtRef = useRef(Date.now());
@@ -990,12 +991,12 @@ function WorkProcess({ blocks, live = false, activeProgressId, startedAt, durati
         const isActive = live && block.id === activeProgressId;
         return <TranscriptOutput key={block.id} text={block.text} streaming={isActive}/>;
       }
-      return <CompactToolCall key={block.id} tool={block.tool} approvalRequest={approvalForTool(block.tool, approvalRequests)}/>;
+      return <CompactToolCall key={block.id} tool={block.tool} approvalRequest={approvalForTool(block.tool, approvalRequests)} codeChanges={codeChanges}/>;
     })}</div>
   </details>;
 }
 
-function LiveWorkStream({ blocks, activeProgressId, startedAt, approvalRequests = [] }: { blocks: WorkBlock[]; activeProgressId?: string; startedAt?: number; approvalRequests?: ApprovalRequest[] }) {
+function LiveWorkStream({ blocks, activeProgressId, startedAt, approvalRequests = [], codeChanges = [] }: { blocks: WorkBlock[]; activeProgressId?: string; startedAt?: number; approvalRequests?: ApprovalRequest[]; codeChanges?: CodeChange[] }) {
   const { tr } = useI18n();
   const fallbackStartedAtRef = useRef(Date.now());
   const [clockNow, setClockNow] = useState(Date.now);
@@ -1009,7 +1010,7 @@ function LiveWorkStream({ blocks, activeProgressId, startedAt, approvalRequests 
     <div className="live-work-status"><Icon name="sparkles" size={12}/><span>{tr('Working', '处理中')}</span><time className="live-work-elapsed" title={tr(`Elapsed ${elapsedLabel}`, `耗时 ${elapsedLabel}`)}>{elapsedLabel}</time></div>
     {blocks.map(block => {
       if (block.type === 'thinking') return <ThoughtDisclosure key={block.id} text={block.text} live/>;
-      if (block.type === 'tool') return <CompactToolCall key={block.id} tool={block.tool} approvalRequest={approvalForTool(block.tool, approvalRequests)}/>;
+      if (block.type === 'tool') return <CompactToolCall key={block.id} tool={block.tool} approvalRequest={approvalForTool(block.tool, approvalRequests)} codeChanges={codeChanges}/>;
       const active = block.id === activeProgressId;
       return <TranscriptOutput key={block.id} text={block.text} streaming={active}/>;
     })}
@@ -1028,12 +1029,14 @@ function ThoughtDisclosure({ text, live = false }: { text: string; live?: boolea
   </details>;
 }
 
-function CompactToolCall({ tool, approvalRequest }: { tool: ToolCall; approvalRequest?: ApprovalRequest }) {
+function CompactToolCall({ tool, approvalRequest, codeChanges = [] }: { tool: ToolCall; approvalRequest?: ApprovalRequest; codeChanges?: CodeChange[] }) {
   if (isExitPlanModeTool(tool.name)) return <ExitPlanModeToolCall tool={tool} approvalRequest={approvalRequest}/>;
   const { tr } = useI18n();
+  const recordedDiff = tool.id ? codeChanges.find(change => change.operationId === tool.id)?.diff : undefined;
+  const detailOptions = recordedDiff !== undefined ? { recordedDiff } : undefined;
   const summary = summarizeToolCall(tool, tr);
   const failed = isToolCallFailed(tool.name, tool.result);
-  const hasDetails = buildToolCallDetailSections(tool).length > 0;
+  const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;
   const statusLabel = tool.result === undefined
     ? tr('Running', '运行中')
     : failed
@@ -1048,7 +1051,7 @@ function CompactToolCall({ tool, approvalRequest }: { tool: ToolCall; approvalRe
       <small className={statusClass}>{statusLabel}</small>
       {hasDetails && <Icon className="tool-call-chevron" name="chevron-right" size={11}/>}
     </summary>
-    {hasDetails && <ToolCallDetailBody tool={tool}/>}
+    {hasDetails && <ToolCallDetailBody tool={tool} recordedDiff={recordedDiff}/>}
   </details>;
 }
 

--- a/apps/nori-web/src/components/ChatView.tsx
+++ b/apps/nori-web/src/components/ChatView.tsx
@@ -15,7 +15,9 @@ import { McpElicitationPanel } from './McpElicitationPanel';
 import { SkillPicker } from './SkillPicker';
 import { UsageOverview } from './UsageOverview';
 import { detectImageMime, isLikelyImageFile } from '../utils/image-mime';
+import { ToolCallDetailBody } from './ToolCallDetailBody';
 import { editLineOperationStats } from '../utils/edit-line-ops';
+import { buildToolCallDetailSections, isToolCallFailed } from '../utils/tool-call-detail';
 
 export interface ChatViewProps {
   session: Session | null;
@@ -1030,11 +1032,24 @@ function CompactToolCall({ tool, approvalRequest }: { tool: ToolCall; approvalRe
   if (isExitPlanModeTool(tool.name)) return <ExitPlanModeToolCall tool={tool} approvalRequest={approvalRequest}/>;
   const { tr } = useI18n();
   const summary = summarizeToolCall(tool, tr);
-  return <div className={`compact-tool-call tool-${tool.name.toLowerCase()}`} title={tool.result?.slice(0, 600)}>
-    <span className="compact-tool-icon"><Icon name={toolCallIcon(tool.name)} size={12}/></span>
-    <span className="compact-tool-copy"><strong>{tool.name}</strong>{summary && <span>{summary}</span>}</span>
-    <small className={tool.result === undefined ? 'running' : 'done'}>{tool.result === undefined ? tr('Running', '运行中') : tr('Done', '完成')}</small>
-  </div>;
+  const failed = isToolCallFailed(tool.name, tool.result);
+  const hasDetails = buildToolCallDetailSections(tool).length > 0;
+  const statusLabel = tool.result === undefined
+    ? tr('Running', '运行中')
+    : failed
+      ? tr('Failed', '失败')
+      : tr('Done', '完成');
+  const statusClass = tool.result === undefined ? 'running' : failed ? 'failed' : 'done';
+
+  return <details className={`compact-tool-call expandable-tool-call tool-${tool.name.toLowerCase()}`}>
+    <summary>
+      <span className="compact-tool-icon"><Icon name={toolCallIcon(tool.name)} size={12}/></span>
+      <span className="compact-tool-copy"><strong>{tool.name}</strong>{summary && <span>{summary}</span>}</span>
+      <small className={statusClass}>{statusLabel}</small>
+      {hasDetails && <Icon className="tool-call-chevron" name="chevron-right" size={11}/>}
+    </summary>
+    {hasDetails && <ToolCallDetailBody tool={tool}/>}
+  </details>;
 }
 
 function ExitPlanModeToolCall({ tool, approvalRequest }: { tool: ToolCall; approvalRequest?: ApprovalRequest }) {

--- a/apps/nori-web/src/components/CodeView.tsx
+++ b/apps/nori-web/src/components/CodeView.tsx
@@ -254,6 +254,7 @@ export function CodeView({
         onResolveMcpElicitation={onResolveMcpElicitation}
         queuedPrompts={queuedPrompts}
         todos={todos}
+        codeChanges={codeChanges}
         onCancelQueuedPrompt={onCancelQueuedPrompt}
         draftAgentConfig={draftAgentConfig}
         rewindLimit={rewindLimit}

--- a/apps/nori-web/src/components/ToolCallDetailBody.tsx
+++ b/apps/nori-web/src/components/ToolCallDetailBody.tsx
@@ -1,8 +1,10 @@
 import type { ToolCall } from '../hooks/useChatMessages';
+import type { ToolCallDetailOptions } from '../utils/tool-call-detail';
 import { buildToolCallDetailSections } from '../utils/tool-call-detail';
 
-export function ToolCallDetailBody({ tool }: { tool: ToolCall }) {
-  const sections = buildToolCallDetailSections(tool);
+export function ToolCallDetailBody({ tool, recordedDiff }: { tool: ToolCall; recordedDiff?: string | undefined }) {
+  const options: ToolCallDetailOptions | undefined = recordedDiff !== undefined ? { recordedDiff } : undefined;
+  const sections = buildToolCallDetailSections(tool, options);
   if (sections.length === 0) return null;
 
   return (
@@ -26,7 +28,7 @@ export function ToolCallDetailBody({ tool }: { tool: ToolCall }) {
                 {section.lines.map((line, lineIndex) => (
                   <span
                     key={`${lineIndex}-${line}`}
-                    className={line.startsWith('+') ? 'added' : line.startsWith('-') ? 'removed' : undefined}
+                    className={line.startsWith('+') ? 'added' : line.startsWith('-') ? 'removed' : line.startsWith('@@') ? 'meta' : undefined}
                   >
                     {line}
                   </span>

--- a/apps/nori-web/src/components/ToolCallDetailBody.tsx
+++ b/apps/nori-web/src/components/ToolCallDetailBody.tsx
@@ -1,0 +1,50 @@
+import type { ToolCall } from '../hooks/useChatMessages';
+import { buildToolCallDetailSections } from '../utils/tool-call-detail';
+
+export function ToolCallDetailBody({ tool }: { tool: ToolCall }) {
+  const sections = buildToolCallDetailSections(tool);
+  if (sections.length === 0) return null;
+
+  return (
+    <div className="tool-call-detail-body">
+      {sections.map((section, index) => {
+        if (section.kind === 'heading') {
+          return (
+            <div key={`heading-${index}`} className="tool-call-detail-heading">
+              {section.label !== undefined && <strong>{section.label}</strong>}
+              {section.text !== undefined && <span>{section.text}</span>}
+            </div>
+          );
+        }
+
+        const label = section.label;
+        if (section.kind === 'diff' && section.lines !== undefined) {
+          return (
+            <section key={`diff-${index}`} className="tool-call-detail-section">
+              {label !== undefined && <header>{label}</header>}
+              <pre className="compact-diff tool-call-detail-diff">
+                {section.lines.map((line, lineIndex) => (
+                  <span
+                    key={`${lineIndex}-${line}`}
+                    className={line.startsWith('+') ? 'added' : line.startsWith('-') ? 'removed' : undefined}
+                  >
+                    {line}
+                  </span>
+                ))}
+              </pre>
+            </section>
+          );
+        }
+
+        const text = section.text ?? '';
+        const tone = section.kind === 'error' ? 'error' : 'pre';
+        return (
+          <section key={`${tone}-${index}`} className={`tool-call-detail-section tool-call-detail-${tone}`}>
+            {label !== undefined && <header>{label}</header>}
+            <pre>{text}</pre>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
+++ b/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { ModelCatalogItem, Session } from '../../api/client';
-import type { ChatMessage, WorkBlock } from '../../hooks/useChatMessages';
+import type { ChatMessage, CodeChange, WorkBlock } from '../../hooks/useChatMessages';
 import { ChatView } from '../ChatView';
 
 const MOCK_STARTED_AT = new Date().toISOString();
@@ -80,6 +80,23 @@ const MESSAGES: ChatMessage[] = [
   },
 ];
 
+const CODE_CHANGES: CodeChange[] = [{
+  operationId: 'mock-edit-tool',
+  agentId: 'main',
+  operation: 'edit',
+  path: 'apps/nori-web/src/components/ChatView.tsx',
+  diff: [
+    '-const summary = summarizeToolCall(tool, tr);',
+    '-return <div className={`compact-tool-call tool-${tool.name.toLowerCase()}`} title={tool.result?.slice(0, 600)}>',
+    '+const summary = summarizeToolCall(tool, tr);',
+    '+const failed = isToolCallFailed(tool.name, tool.result);',
+    '+const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;',
+    '-',
+    '-',
+  ].join('\n'),
+  occurredAt: MOCK_STARTED_AT,
+}];
+
 export function ToolCallDetailMockPage() {
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -115,6 +132,7 @@ export function ToolCallDetailMockPage() {
         onTaskModeChange={() => undefined}
         onRunSlashCommand={() => false}
         onMainWriteChange={() => undefined}
+        codeChanges={CODE_CHANGES}
       />
     </main>
   </div>;

--- a/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
+++ b/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from 'react';
+import type { ModelCatalogItem, Session } from '../../api/client';
+import type { ChatMessage, WorkBlock } from '../../hooks/useChatMessages';
+import { ChatView } from '../ChatView';
+
+const MOCK_STARTED_AT = new Date().toISOString();
+
+const SESSION: Session = {
+  id: 'mock-tool-call-detail-session',
+  title: 'Tool call detail preview',
+  status: 'idle',
+  created_at: MOCK_STARTED_AT,
+  updated_at: MOCK_STARTED_AT,
+  message_count: 2,
+  metadata: { cwd: '/workspace' },
+  agent_config: {
+    model: 'mock/gpt-5.4',
+    thinking: 'high',
+    permission_mode: 'auto',
+    plan_mode: false,
+    main_write_enabled: true,
+  },
+};
+
+const MODELS: ModelCatalogItem[] = [{
+  provider: 'mock',
+  model: 'mock/gpt-5.4',
+  display_name: 'GPT-5.4 Mock',
+  max_context_size: 200_000,
+  capabilities: ['thinking', 'tool_use'],
+}];
+
+const WORK_BLOCKS: WorkBlock[] = [
+  {
+    id: 'mock-edit-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-edit-tool',
+      name: 'Edit',
+      args: {
+        path: 'apps/nori-web/src/components/ChatView.tsx',
+        expected_tag: 'A1B2',
+        line_ops: [
+          { op: 'swap', start: 42, end: 44, content: 'const summary = summarizeToolCall(tool, tr);\nconst failed = isToolCallFailed(tool.name, tool.result);\nconst hasDetails = buildToolCallDetailSections(tool).length > 0;' },
+          { op: 'del', start: 88, end: 89 },
+        ],
+      },
+      result: 'Updated apps/nori-web/src/components/ChatView.tsx (+3 -2)',
+    },
+  },
+  {
+    id: 'mock-browser-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-browser-tool',
+      name: 'Browser',
+      args: {
+        action: 'navigate',
+        url: 'https://example.com/docs/api',
+        tab_id: 'tab-1',
+      },
+      result: 'Navigated to https://example.com/docs/api\nTitle: API Reference · Example Docs\nSnapshot: 24 interactive elements, 3 scroll regions.',
+    },
+  },
+];
+
+const MESSAGES: ChatMessage[] = [
+  {
+    id: 'mock-user-message',
+    role: 'user',
+    text: '请修改 ChatView 并打开文档页核对 API 说明。',
+    createdAt: MOCK_STARTED_AT,
+  },
+  {
+    id: 'mock-assistant-message',
+    role: 'assistant',
+    text: '已完成代码修改，并在浏览器中打开了文档页面进行核对。',
+    workBlocks: WORK_BLOCKS,
+    createdAt: new Date(Date.now() + 12_000).toISOString(),
+  },
+];
+
+export function ToolCallDetailMockPage() {
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      for (const element of document.querySelectorAll('.chat-work-process, .expandable-tool-call')) {
+        if (element instanceof HTMLDetailsElement) element.open = true;
+      }
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return <div className="tool-call-detail-mock-page">
+    <header className="exit-plan-mock-header">
+      <span className="exit-plan-mock-brand">Nori Work</span>
+      <strong>Tool call details</strong>
+      <span className="exit-plan-mock-status">Edit + Browser preview</span>
+    </header>
+    <main className="exit-plan-mock-content">
+      <ChatView
+        session={SESSION}
+        messages={MESSAGES}
+        streaming=""
+        thinking=""
+        isStreaming={false}
+        models={MODELS}
+        modelsLoading={false}
+        modelError={null}
+        onSendMessage={() => false}
+        onAbort={() => false}
+        onRefreshModels={() => undefined}
+        onModelChange={() => undefined}
+        onThinkingChange={() => undefined}
+        onPermissionChange={() => undefined}
+        onTaskModeChange={() => undefined}
+        onRunSlashCommand={() => false}
+        onMainWriteChange={() => undefined}
+      />
+    </main>
+  </div>;
+}

--- a/apps/nori-web/src/main.tsx
+++ b/apps/nori-web/src/main.tsx
@@ -6,6 +6,7 @@ import { initializeTheme } from './theme';
 import { InspectorPopout } from './components/InspectorPopout';
 import type { InspectorTab } from './components/WorkspaceInspector';
 import { ExitPlanModeMockPage } from './components/dev/ExitPlanModeMockPage';
+import { ToolCallDetailMockPage } from './components/dev/ToolCallDetailMockPage';
 import './styles/nori-theme.css';
 import './styles/linear-flat.css';
 
@@ -15,6 +16,8 @@ const mockScenario = new URLSearchParams(window.location.search).get('mock');
 const inspector = hashParams.get('inspector') as InspectorTab | null;
 const content = import.meta.env.DEV && mockScenario === 'exit-plan-mode'
   ? <ExitPlanModeMockPage />
+  : import.meta.env.DEV && mockScenario === 'tool-call-detail'
+    ? <ToolCallDetailMockPage />
   : inspector && ['preview', 'changes', 'browser', 'git', 'lsp', 'terminal'].includes(inspector)
   ? <InspectorPopout tab={inspector} sessionId={hashParams.get('session')} path={hashParams.get('path') ?? ''}/>
   : <App />;

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -2492,6 +2492,7 @@ kbd {
 .compact-tool-call > span:nth-child(3) { min-width: 0; overflow: hidden; color: var(--nori-text-muted); font-family: var(--nori-font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .compact-tool-call > small { color: var(--nori-success); font-size: calc(8px * var(--nori-ui-font-scale)); }
 .compact-tool-call > small.running { color: var(--nori-warning); }
+.compact-tool-call > small.failed { color: var(--nori-danger); }
 
 /* Swarm navigation states and compact per-round output. */
 .sidebar-nav-item.activity-pending,
@@ -4356,6 +4357,21 @@ kbd {
 .exit-plan-tool-call > summary > small.running { color: var(--nori-warning); }
 .exit-plan-chevron { color: var(--nori-text-muted); transform: rotate(0deg); transition: transform 160ms ease, color 160ms ease; }
 .exit-plan-tool-call[open] .exit-plan-chevron { color: var(--nori-text-secondary); transform: rotate(90deg); }
+.expandable-tool-call { display: block; min-width: 0; padding: 0; border: 0; border-radius: 0; background: transparent; }
+.expandable-tool-call > summary { display: grid; min-height: 30px; grid-template-columns: 20px minmax(0, 1fr) auto 14px; align-items: center; gap: 7px; padding: 3px 0; cursor: pointer; list-style: none; }
+.expandable-tool-call > summary::-webkit-details-marker { display: none; }
+.expandable-tool-call > summary > small.failed { color: var(--nori-danger); }
+.tool-call-chevron { color: var(--nori-text-muted); transform: rotate(0deg); transition: transform 160ms ease, color 160ms ease; }
+.expandable-tool-call[open] .tool-call-chevron { color: var(--nori-text-secondary); transform: rotate(90deg); }
+.tool-call-detail-body { display: grid; gap: 8px; margin: 4px 0 6px 27px; }
+.tool-call-detail-section { display: grid; gap: 4px; }
+.tool-call-detail-section > header { color: var(--nori-text-muted); font-size: calc(8px * var(--nori-ui-font-scale)); font-weight: 650; text-transform: uppercase; letter-spacing: .04em; }
+.tool-call-detail-section > pre,
+.tool-call-detail-error > pre { max-height: min(42vh, 520px); margin: 0; padding: 8px 10px; overflow: auto; border: 1px solid var(--nori-border); border-radius: 5px; background: var(--nori-bg); color: var(--nori-text-secondary); font: calc(9px * var(--nori-ui-font-scale))/1.55 var(--nori-font-mono); white-space: pre-wrap; overflow-wrap: anywhere; }
+.tool-call-detail-error > pre { color: var(--nori-danger); border-color: color-mix(in srgb, var(--nori-danger) 28%, var(--nori-border)); background: color-mix(in srgb, var(--nori-danger) 6%, var(--nori-bg)); }
+.tool-call-detail-diff { max-height: min(42vh, 520px); margin: 0; border: 1px solid var(--nori-border); border-radius: 5px; }
+.tool-call-detail-heading { display: flex; align-items: center; gap: 6px; color: var(--nori-text-muted); font-size: calc(9px * var(--nori-ui-font-scale)); }
+.tool-call-detail-heading > strong { color: var(--nori-text-secondary); font-weight: 650; }
 .exit-plan-markdown { max-height: min(52vh, 720px); margin: 4px 0 6px 27px; padding: 12px 14px; overflow: auto; border: 1px solid var(--nori-border); border-radius: 5px; background: var(--nori-bg); }
 .exit-plan-markdown .markdown-view { max-width: none; color: var(--nori-text-secondary); font-size: calc(11px * var(--nori-ui-font-scale)); line-height: 1.65; }
 .exit-plan-markdown .markdown-view h1 { font-size: calc(17px * var(--nori-ui-font-scale)); }

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -3742,6 +3742,7 @@ kbd {
 .compact-diff span, .git-diff-view pre span { display: block; min-width: max-content; padding: 0 11px; white-space: pre; }
 .compact-diff .added, .git-diff-view .added { color: var(--nori-success); background: color-mix(in srgb, var(--nori-success) 8%, transparent); }
 .compact-diff .removed, .git-diff-view .removed { color: var(--nori-danger); background: color-mix(in srgb, var(--nori-danger) 8%, transparent); }
+.compact-diff .meta { color: var(--nori-text-muted); background: transparent; }
 .git-unavailable { gap: 7px; padding-inline: 20px; text-align: center; }
 .git-unavailable strong { color: var(--nori-text-secondary); font-size: calc(11px * var(--nori-ui-font-scale)); }
 .git-unavailable span { max-width: 100%; overflow-wrap: anywhere; }

--- a/apps/nori-web/src/utils/edit-line-ops.ts
+++ b/apps/nori-web/src/utils/edit-line-ops.ts
@@ -56,15 +56,23 @@ export function editLineOperationStats(value: unknown): { additions: number; del
   return { additions, deletions };
 }
 
+export function editOperationLabel(operation: EditLineOperation): string {
+  switch (operation.op) {
+    case 'swap':
+      return `replace lines ${String(operation.start)}-${String(operation.end)}`;
+    case 'del':
+      return `delete lines ${String(operation.start)}-${String(operation.end)}`;
+    case 'insert_pre':
+      return `insert before line ${String(operation.line)}`;
+    case 'insert_post':
+      return `insert after line ${String(operation.line)}`;
+  }
+}
+
 export function editLineOperationsDiff(value: unknown): string[] {
   const lines: string[] = [];
   for (const operation of parseEditLineOperations(value)) {
-    if (operation.op === 'swap' || operation.op === 'del') {
-      const action = operation.op === 'swap' ? 'replaced' : 'deleted';
-      for (let line = operation.start; line <= operation.end; line += 1) {
-        lines.push(`- [original line ${String(line)} ${action}]`);
-      }
-    }
+    lines.push(`@@ ${editOperationLabel(operation)} @@`);
     if (operation.op !== 'del') {
       const contentLines = operation.content.replaceAll('\r\n', '\n').split('\n');
       if (operation.content.endsWith('\n')) contentLines.pop();

--- a/apps/nori-web/src/utils/tool-call-detail.ts
+++ b/apps/nori-web/src/utils/tool-call-detail.ts
@@ -1,0 +1,169 @@
+import type { ToolCall } from '../hooks/useChatMessages';
+import { editLineOperationsDiff, parseEditLineOperations } from './edit-line-ops';
+
+export interface ToolCallDetailSection {
+  readonly kind: 'heading' | 'diff' | 'pre' | 'error';
+  readonly label?: string;
+  readonly lines?: readonly string[];
+  readonly text?: string;
+}
+
+const MAX_DIFF_LINES = 80;
+const MAX_PRE_CHARS = 24_000;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function normalizeToolName(name: string): string {
+  return name.replaceAll(/[-_\s]/g, '').toLowerCase();
+}
+
+export function isToolCallFailed(name: string, result: string | undefined): boolean {
+  if (result === undefined || result.trim().length === 0) return false;
+  const trimmed = result.trimStart();
+  if (/^Error[:\s]/i.test(trimmed)) return true;
+  if (/Command failed with exit code: [1-9]\d*\./.test(result)) return true;
+  if (/^Tool execution failed\b/i.test(trimmed)) return true;
+  if (normalizeToolName(name) === 'bash' && /exit code: [1-9]\d*/i.test(result)) return true;
+  return false;
+}
+
+function writeContentDiff(content: unknown): string {
+  if (typeof content !== 'string' || content.length === 0) return '';
+  return content
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map(line => `+${line}`)
+    .join('\n');
+}
+
+function compactDiffLines(diff: string): string[] {
+  const lines = diff.split('\n').filter(line =>
+    (line.startsWith('+') && !line.startsWith('+++'))
+    || (line.startsWith('-') && !line.startsWith('---')),
+  );
+  if (lines.length <= MAX_DIFF_LINES) return lines;
+  return [...lines.slice(0, MAX_DIFF_LINES), `... ${String(lines.length - MAX_DIFF_LINES)} more changed lines`];
+}
+
+export function buildToolCallChangeDiff(tool: ToolCall): string | undefined {
+  const args = asRecord(tool.args);
+  const normalized = normalizeToolName(tool.name);
+
+  if (normalized === 'edit') {
+    const diff = editLineOperationsDiff(args['line_ops']).join('\n');
+    return diff.length > 0 ? diff : undefined;
+  }
+  if (normalized === 'write') {
+    const diff = writeContentDiff(args['content']);
+    return diff.length > 0 ? diff : undefined;
+  }
+
+  const resultDiff = tool.result?.trim();
+  if (resultDiff !== undefined && resultDiff.length > 0 && looksLikeUnifiedDiff(resultDiff)) {
+    return resultDiff;
+  }
+  return undefined;
+}
+
+function looksLikeUnifiedDiff(text: string): boolean {
+  return text.includes('@@') && (text.includes('\n+') || text.includes('\n-'));
+}
+
+function truncatePre(text: string): string {
+  if (text.length <= MAX_PRE_CHARS) return text;
+  return `${text.slice(0, MAX_PRE_CHARS)}\n... truncated`;
+}
+
+function formatArgsSummary(tool: ToolCall, excludeKeys: Set<string>): string | undefined {
+  const args = asRecord(tool.args);
+  const entries = Object.entries(args).filter(([key, value]) => {
+    if (excludeKeys.has(key)) return false;
+    if (value === undefined || value === null) return false;
+    if (typeof value === 'string' && value.length === 0) return false;
+    return true;
+  });
+  if (entries.length === 0) return undefined;
+
+  const lines: string[] = [];
+  for (const [key, value] of entries) {
+    if (typeof value === 'string') {
+      const preview = value.length > 240 ? `${value.slice(0, 240)}…` : value;
+      lines.push(`${key}: ${preview}`);
+      continue;
+    }
+    try {
+      const serialized = JSON.stringify(value);
+      const preview = serialized.length > 240 ? `${serialized.slice(0, 240)}…` : serialized;
+      lines.push(`${key}: ${preview}`);
+    } catch {
+      lines.push(`${key}: [unserializable]`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function buildToolCallDetailSections(tool: ToolCall): ToolCallDetailSection[] {
+  const sections: ToolCallDetailSection[] = [];
+  const normalized = normalizeToolName(tool.name);
+  const args = asRecord(tool.args);
+  const failed = isToolCallFailed(tool.name, tool.result);
+  const changeDiff = buildToolCallChangeDiff(tool);
+
+  const excludeArgKeys = new Set<string>();
+  if (normalized === 'write') excludeArgKeys.add('content');
+  if (normalized === 'edit') excludeArgKeys.add('line_ops');
+  if (normalized === 'bash') excludeArgKeys.add('command');
+
+  const argsSummary = formatArgsSummary(tool, excludeArgKeys);
+  if (argsSummary !== undefined) {
+    sections.push({ kind: 'pre', label: 'Input', text: argsSummary });
+  }
+
+  if (normalized === 'bash') {
+    const command = firstString(args['command']);
+    if (command !== undefined) {
+      sections.push({ kind: 'pre', label: 'Command', text: `$ ${command}` });
+    }
+  }
+
+  if (normalized === 'edit' && parseEditLineOperations(args['line_ops']).length > 0) {
+    sections.push({
+      kind: 'heading',
+      label: 'Line operations',
+      text: `${String(parseEditLineOperations(args['line_ops']).length)} operation(s)`,
+    });
+  }
+
+  if (changeDiff !== undefined) {
+    sections.push({
+      kind: 'diff',
+      label: normalized === 'write' ? 'New content' : 'Changes',
+      lines: compactDiffLines(changeDiff),
+    });
+  }
+
+  if (tool.result !== undefined) {
+    const trimmed = tool.result.trim();
+    if (trimmed.length > 0) {
+      if (failed) {
+        sections.push({ kind: 'error', label: 'Failure', text: truncatePre(tool.result) });
+      } else if (changeDiff === undefined || !trimmed.startsWith(changeDiff.slice(0, 32))) {
+        sections.push({
+          kind: 'pre',
+          label: normalized === 'bash' ? 'Output' : 'Result',
+          text: truncatePre(tool.result),
+        });
+      }
+    }
+  }
+
+  return sections;
+}

--- a/apps/nori-web/src/utils/tool-call-detail.ts
+++ b/apps/nori-web/src/utils/tool-call-detail.ts
@@ -1,5 +1,9 @@
-import type { ToolCall } from '../hooks/useChatMessages';
+import type { CodeChange, ToolCall } from '../hooks/useChatMessages';
 import { editLineOperationsDiff, parseEditLineOperations } from './edit-line-ops';
+
+export interface ToolCallDetailOptions {
+  readonly recordedDiff?: string | undefined;
+}
 
 export interface ToolCallDetailSection {
   readonly kind: 'heading' | 'diff' | 'pre' | 'error';
@@ -46,18 +50,30 @@ function writeContentDiff(content: unknown): string {
 
 function compactDiffLines(diff: string): string[] {
   const lines = diff.split('\n').filter(line =>
-    (line.startsWith('+') && !line.startsWith('+++'))
-    || (line.startsWith('-') && !line.startsWith('---')),
+    line.startsWith('@@')
+    || ((line.startsWith('+') && !line.startsWith('+++'))
+    || (line.startsWith('-') && !line.startsWith('---'))),
   );
   if (lines.length <= MAX_DIFF_LINES) return lines;
   return [...lines.slice(0, MAX_DIFF_LINES), `... ${String(lines.length - MAX_DIFF_LINES)} more changed lines`];
 }
 
-export function buildToolCallChangeDiff(tool: ToolCall): string | undefined {
+function hasTextDiff(diff: string): boolean {
+  return diff.split('\n').some(line =>
+    (line.startsWith('+') && !line.startsWith('+++'))
+    || (line.startsWith('-') && !line.startsWith('---')),
+  );
+}
+
+export function buildToolCallChangeDiff(tool: ToolCall, options?: ToolCallDetailOptions): string | undefined {
   const args = asRecord(tool.args);
   const normalized = normalizeToolName(tool.name);
+  const recordedDiff = options?.recordedDiff?.trim();
 
   if (normalized === 'edit') {
+    if (recordedDiff !== undefined && recordedDiff.length > 0 && hasTextDiff(recordedDiff)) {
+      return recordedDiff;
+    }
     const diff = editLineOperationsDiff(args['line_ops']).join('\n');
     return diff.length > 0 ? diff : undefined;
   }
@@ -110,12 +126,12 @@ function formatArgsSummary(tool: ToolCall, excludeKeys: Set<string>): string | u
   return lines.join('\n');
 }
 
-export function buildToolCallDetailSections(tool: ToolCall): ToolCallDetailSection[] {
+export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDetailOptions): ToolCallDetailSection[] {
   const sections: ToolCallDetailSection[] = [];
   const normalized = normalizeToolName(tool.name);
   const args = asRecord(tool.args);
   const failed = isToolCallFailed(tool.name, tool.result);
-  const changeDiff = buildToolCallChangeDiff(tool);
+  const changeDiff = buildToolCallChangeDiff(tool, options);
 
   const excludeArgKeys = new Set<string>();
   if (normalized === 'write') excludeArgKeys.add('content');

--- a/apps/nori-web/test/ChatView.test.ts
+++ b/apps/nori-web/test/ChatView.test.ts
@@ -1190,6 +1190,60 @@ describe('conversation presentation', () => {
     expect(container.querySelector('.transcript-assistant-output')?.textContent).toContain('The target file is loaded.');
   });
 
+  it('expands tool call details with diff and failure output', async () => {
+    const blocks = [
+      {
+        id: 'tool-edit-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-edit-1',
+          name: 'Edit',
+          args: {
+            path: 'src/a.ts',
+            line_ops: [{ op: 'swap', start: 1, end: 1, content: 'updated' }],
+          },
+          result: 'Updated src/a.ts',
+        },
+      },
+      {
+        id: 'tool-bash-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-bash-1',
+          name: 'Bash',
+          args: { command: 'npm test' },
+          result: 'stderr\nCommand failed with exit code: 1.',
+        },
+      },
+    ];
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: 'Done.', workBlocks: blocks }],
+      isStreaming: false,
+    });
+
+    const toolCalls = container.querySelectorAll<HTMLDetailsElement>('.expandable-tool-call');
+    expect(toolCalls).toHaveLength(2);
+
+    const editDetails = toolCalls[0]!;
+    expect(editDetails.textContent).toContain('Edit');
+    expect(editDetails.textContent).toContain('src/a.ts');
+    await act(async () => {
+      editDetails.querySelector('summary')?.click();
+      await Promise.resolve();
+    });
+    expect(editDetails.open).toBe(true);
+    expect(editDetails.textContent).toContain('+updated');
+
+    const bashDetails = toolCalls[1]!;
+    expect(bashDetails.textContent).toContain('Failed');
+    await act(async () => {
+      bashDetails.querySelector('summary')?.click();
+      await Promise.resolve();
+    });
+    expect(bashDetails.textContent).toContain('npm test');
+    expect(bashDetails.textContent).toContain('Command failed with exit code: 1.');
+  });
+
   it('renders ordinary live text as normal assistant output while work is active', async () => {
     const { container } = await renderChat({
       messages: [{ id: 'assistant-1', role: 'assistant', text: 'The first inspection pass is complete.' }],

--- a/apps/nori-web/test/tool-call-detail.test.ts
+++ b/apps/nori-web/test/tool-call-detail.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildToolCallChangeDiff,
+  buildToolCallDetailSections,
+  isToolCallFailed,
+} from '../src/utils/tool-call-detail';
+
+describe('tool-call-detail', () => {
+  it('detects bash failures from exit code output', () => {
+    expect(isToolCallFailed('Bash', 'stdout\nCommand failed with exit code: 2.')).toBe(true);
+    expect(isToolCallFailed('Bash', 'stdout\nCommand failed with exit code: 0.')).toBe(false);
+  });
+
+  it('builds edit diff lines from line_ops', () => {
+    const diff = buildToolCallChangeDiff({
+      name: 'Edit',
+      args: {
+        path: 'src/a.ts',
+        line_ops: [{ op: 'swap', start: 1, end: 1, content: 'new line' }],
+      },
+    });
+    expect(diff).toContain('- [original line 1 replaced]');
+    expect(diff).toContain('+new line');
+  });
+
+  it('builds write diff from content', () => {
+    const diff = buildToolCallChangeDiff({
+      name: 'Write',
+      args: { path: 'README.md', content: 'hello\nworld' },
+    });
+    expect(diff).toBe('+hello\n+world');
+  });
+
+  it('includes command, diff, and failure sections for failed bash calls', () => {
+    const sections = buildToolCallDetailSections({
+      name: 'Bash',
+      args: { command: 'npm test' },
+      result: 'stderr\nCommand failed with exit code: 1.',
+    });
+    expect(sections.some(section => section.label === 'Command' && section.text?.includes('npm test'))).toBe(true);
+    expect(sections.some(section => section.kind === 'error')).toBe(true);
+  });
+
+  it('omits duplicate result body when it matches the change diff', () => {
+    const sections = buildToolCallDetailSections({
+      name: 'Write',
+      args: { path: 'a.txt', content: 'line' },
+      result: '+line',
+    });
+    expect(sections.filter(section => section.label === 'Result')).toHaveLength(0);
+    expect(sections.some(section => section.kind === 'diff')).toBe(true);
+  });
+});

--- a/apps/nori-web/test/tool-call-detail.test.ts
+++ b/apps/nori-web/test/tool-call-detail.test.ts
@@ -12,7 +12,7 @@ describe('tool-call-detail', () => {
     expect(isToolCallFailed('Bash', 'stdout\nCommand failed with exit code: 0.')).toBe(false);
   });
 
-  it('builds edit diff lines from line_ops', () => {
+  it('builds edit preview lines from line_ops when no recorded diff exists', () => {
     const diff = buildToolCallChangeDiff({
       name: 'Edit',
       args: {
@@ -20,8 +20,23 @@ describe('tool-call-detail', () => {
         line_ops: [{ op: 'swap', start: 1, end: 1, content: 'new line' }],
       },
     });
-    expect(diff).toContain('- [original line 1 replaced]');
+    expect(diff).toContain('@@ replace lines 1-1 @@');
     expect(diff).toContain('+new line');
+    expect(diff).not.toContain('[original line');
+  });
+
+  it('prefers recorded diff from code.change events for Edit tools', () => {
+    const diff = buildToolCallChangeDiff({
+      id: 'edit-1',
+      name: 'Edit',
+      args: {
+        path: 'src/a.ts',
+        line_ops: [{ op: 'swap', start: 1, end: 1, content: 'new line' }],
+      },
+    }, {
+      recordedDiff: '-old line\n+new line',
+    });
+    expect(diff).toBe('-old line\n+new line');
   });
 
   it('builds write diff from content', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issue

SUD-14 — 支持查看工具调用的详细变更信息

## Problem

Web 聊天界面中的工具调用行只展示工具名与一行摘要（路径、行数统计等），用户无法展开查看本次调用的输入参数、变更 diff、命令输出或失败原因，难以快速定位 agent 具体做了什么。

TUI 已通过 Ctrl+O 支持展开；Web 端除 ExitPlanMode 外缺少同等能力。

## What changed

- 将 `CompactToolCall` 改为可展开的 `<details>` 行（与 ExitPlanMode 交互一致），默认折叠，不影响现有浏览体验。
- 新增 `tool-call-detail` 工具模块与 `ToolCallDetailBody` 组件，按工具类型组装详情：
  - **Edit / Write**：展示行级变更 diff（`+` / `-` 着色，复用 `compact-diff` 样式）。
  - **Bash**：展示命令与输出；根据 exit code 文案识别失败并标红。
  - **Browser** 等通用工具：展示关键输入参数摘要与完整结果文本。
- 失败调用显示「失败」状态，并在展开区突出错误输出。
- 补充 dev mock 页面 `?mock=tool-call-detail` 与截图脚本，便于本地预览 Edit / Browser 渲染效果。
- 补充单元测试（`tool-call-detail.test.ts`、`ChatView.test.ts`）。

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SUD-14](https://linear.app/sudden/issue/SUD-14/支持查看工具调用的详细变更信息)

<div><a href="https://cursor.com/agents/bc-38085aeb-b479-4456-844f-63990f0e1350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38085aeb-b479-4456-844f-63990f0e1350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

