### PR TITLE
fix(web): match provider API key mask length and keep value on focus

### DIFF
--- a/.changeset/fix-provider-api-key-mask-display.md
+++ b/.changeset/fix-provider-api-key-mask-display.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/nori-code": patch
+"nori-code": patch
 ---
 
 Fix provider settings API key masking so hidden dots match the saved key length and clicking the field no longer clears it before you edit or reveal the key.

--- a/.changeset/fix-provider-api-key-mask-display.md
+++ b/.changeset/fix-provider-api-key-mask-display.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/nori-code": patch
+---
+
+Fix provider settings API key masking so hidden dots match the saved key length and clicking the field no longer clears it before you edit or reveal the key.

--- a/apps/nori-web/src/api/client.ts
+++ b/apps/nori-web/src/api/client.ts
@@ -307,6 +307,7 @@ export interface ProviderCatalogItem {
   base_url?: string;
   default_model?: string;
   has_api_key: boolean;
+  api_key_length?: number;
   status: 'connected' | 'error' | 'unconfigured';
   disabled?: boolean;
   auto_discover?: boolean;

--- a/apps/nori-web/src/components/ProviderSettings.tsx
+++ b/apps/nori-web/src/components/ProviderSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ClipboardEvent, type KeyboardEvent } from 'react';
 
 import { api, type ProviderCatalogItem, type ProviderPreset, type ProviderRefreshResult, type ProviderTestResponse } from '../api/client';
 import { useI18n } from '../i18n';
@@ -14,8 +14,12 @@ const API_FORMATS: Array<{ value: ProviderType; label: string }> = [
   { value: 'vertexai', label: 'Vertex AI' },
 ];
 
-const MASKED_API_KEY = '••••••••';
 const CUSTOM_PRESET_ID = 'custom';
+
+function maskApiKey(length: number | undefined): string {
+  if (length === undefined || length <= 0) return '';
+  return '•'.repeat(length);
+}
 
 interface ProviderDraft {
   originalId: string | null;
@@ -28,6 +32,7 @@ interface ProviderDraft {
   customModels: string;
   disabled: boolean;
   hasStoredKey: boolean;
+  storedKeyLength?: number;
 }
 
 const EMPTY_DRAFT: ProviderDraft = {
@@ -41,6 +46,7 @@ const EMPTY_DRAFT: ProviderDraft = {
   customModels: '',
   disabled: false,
   hasStoredKey: false,
+  storedKeyLength: undefined,
 };
 
 export function ProviderSettings() {
@@ -98,6 +104,7 @@ export function ProviderSettings() {
       customModels: (provider.custom_models ?? []).join('\n'),
       disabled: provider.disabled === true,
       hasStoredKey: provider.has_api_key === true,
+      storedKeyLength: provider.api_key_length,
     });
     setPresetId(matchingPresetId(provider, presets));
     setShowApiKey(false);
@@ -143,11 +150,9 @@ export function ProviderSettings() {
     });
   };
 
-  const beginApiKeyEdit = () => {
-    if (apiKeyTouched || secretLoaded) return;
-    if (!draft?.hasStoredKey) return;
+  const beginApiKeyEdit = (value: string) => {
     setApiKeyTouched(true);
-    updateDraft('apiKey', '');
+    updateDraft('apiKey', value);
   };
 
   const changeApiKey = (value: string) => {
@@ -329,7 +334,25 @@ export function ProviderSettings() {
 
   const displayedApiKey = secretLoaded || apiKeyTouched
     ? (draft?.apiKey ?? '')
-    : (draft?.hasStoredKey ? MASKED_API_KEY : '');
+    : (draft?.hasStoredKey ? maskApiKey(draft.storedKeyLength) : '');
+  const isMaskedReadonly = Boolean(
+    draft?.hasStoredKey && !secretLoaded && !apiKeyTouched,
+  );
+
+  const handleApiKeyKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!isMaskedReadonly) return;
+    if (event.key.length !== 1 || event.ctrlKey || event.metaKey || event.altKey) return;
+    event.preventDefault();
+    beginApiKeyEdit(event.key);
+  };
+
+  const handleApiKeyPaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    if (!isMaskedReadonly) return;
+    const pasted = event.clipboardData.getData('text');
+    if (!pasted) return;
+    event.preventDefault();
+    beginApiKeyEdit(pasted);
+  };
 
   return <div className="provider-settings">
     <header className="provider-settings-heading">
@@ -340,8 +363,8 @@ export function ProviderSettings() {
     {loading ? <div className="provider-empty"><span className="spinner"/></div> : providers.length === 0 && expandedId === null ? <div className="provider-empty"><Icon name="shield" size={22}/><strong>{tr('No providers configured', '还没有配置供应商')}</strong><span>{tr('Add a provider to make models available in chat.', '新增供应商后，模型才会出现在对话选择器中。')}</span></div> : <div className="provider-list">
       {providers.map(provider => <ProviderCard key={provider.id} provider={provider} expanded={expandedId === provider.id} busy={busyId === provider.id} onOpen={() => openProvider(provider)} onTest={() => void testProvider(provider)} onToggle={() => void toggleDisabled(provider)} onDelete={() => void deleteProvider(provider)} />)}
     </div>}
-    {expandedId === '__new__' && draft && <ProviderEditor draft={draft} saving={saving} isNew presets={presets} presetId={presetId} presetWarning={presetWarning} displayedApiKey={displayedApiKey} showApiKey={showApiKey} onApplyPreset={applyPreset} onChange={updateDraft} onBeginApiKeyEdit={beginApiKeyEdit} onChangeApiKey={changeApiKey} onToggleApiKeyVisibility={() => void toggleApiKeyVisibility()} onCopyApiKey={() => void copyApiKey()} onSave={() => void saveProvider()} onCancel={closeEditor} tr={tr} />}
-    {expandedId !== null && expandedId !== '__new__' && draft && <ProviderEditor draft={draft} saving={saving} presets={presets} presetId={presetId} presetWarning={presetWarning} displayedApiKey={displayedApiKey} showApiKey={showApiKey} onApplyPreset={applyPreset} onChange={updateDraft} onBeginApiKeyEdit={beginApiKeyEdit} onChangeApiKey={changeApiKey} onToggleApiKeyVisibility={() => void toggleApiKeyVisibility()} onCopyApiKey={() => void copyApiKey()} onSave={() => void saveProvider()} onCancel={closeEditor} tr={tr} />}
+    {expandedId === '__new__' && draft && <ProviderEditor draft={draft} saving={saving} isNew presets={presets} presetId={presetId} presetWarning={presetWarning} displayedApiKey={displayedApiKey} showApiKey={showApiKey} isMaskedReadonly={isMaskedReadonly} onApplyPreset={applyPreset} onChange={updateDraft} onChangeApiKey={changeApiKey} onApiKeyKeyDown={handleApiKeyKeyDown} onApiKeyPaste={handleApiKeyPaste} onToggleApiKeyVisibility={() => void toggleApiKeyVisibility()} onCopyApiKey={() => void copyApiKey()} onSave={() => void saveProvider()} onCancel={closeEditor} tr={tr} />}
+    {expandedId !== null && expandedId !== '__new__' && draft && <ProviderEditor draft={draft} saving={saving} presets={presets} presetId={presetId} presetWarning={presetWarning} displayedApiKey={displayedApiKey} showApiKey={showApiKey} isMaskedReadonly={isMaskedReadonly} onApplyPreset={applyPreset} onChange={updateDraft} onChangeApiKey={changeApiKey} onApiKeyKeyDown={handleApiKeyKeyDown} onApiKeyPaste={handleApiKeyPaste} onToggleApiKeyVisibility={() => void toggleApiKeyVisibility()} onCopyApiKey={() => void copyApiKey()} onSave={() => void saveProvider()} onCancel={closeEditor} tr={tr} />}
   </div>;
 }
 
@@ -372,10 +395,12 @@ function ProviderEditor({
   presetWarning,
   displayedApiKey,
   showApiKey,
+  isMaskedReadonly,
   onApplyPreset,
   onChange,
-  onBeginApiKeyEdit,
   onChangeApiKey,
+  onApiKeyKeyDown,
+  onApiKeyPaste,
   onToggleApiKeyVisibility,
   onCopyApiKey,
   onSave,
@@ -390,10 +415,12 @@ function ProviderEditor({
   presetWarning: string;
   displayedApiKey: string;
   showApiKey: boolean;
+  isMaskedReadonly: boolean;
   onApplyPreset: (id: string) => void;
   onChange: <K extends keyof ProviderDraft>(key: K, value: ProviderDraft[K]) => void;
-  onBeginApiKeyEdit: () => void;
   onChangeApiKey: (value: string) => void;
+  onApiKeyKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onApiKeyPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
   onToggleApiKeyVisibility: () => void;
   onCopyApiKey: () => void;
   onSave: () => void;
@@ -409,7 +436,7 @@ function ProviderEditor({
       <label><span>Provider ID</span><input aria-label="Provider ID" value={draft.id} onChange={event => onChange('id', event.target.value.trim())} placeholder="openrouter" /></label>
       <label><span>{tr('API format', 'API 格式')}</span><select value={draft.type} onChange={event => onChange('type', event.target.value as ProviderType)}>{API_FORMATS.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}</select></label>
       <label className="provider-form-wide"><span>Base URL</span><input value={draft.baseUrl} onChange={event => onChange('baseUrl', event.target.value)} placeholder="https://api.example.com/v1" /></label>
-      <label className="provider-form-wide"><span>API Key</span><div className="provider-secret-input"><input aria-label="API Key" type={showApiKey ? 'text' : 'password'} value={displayedApiKey} onFocus={onBeginApiKeyEdit} onChange={event => onChangeApiKey(event.target.value)} placeholder={draft.hasStoredKey ? tr('Enter a new key to replace the stored one', '输入新密钥以替换已保存的密钥') : 'sk-...'}/><button type="button" onClick={onToggleApiKeyVisibility} title={showApiKey ? tr('Hide API key', '隐藏 API Key') : tr('Show API key', '显示 API Key')} aria-label={showApiKey ? tr('Hide API key', '隐藏 API Key') : tr('Show API key', '显示 API Key')}><Icon name="eye" size={14}/></button><button type="button" onClick={onCopyApiKey} title={tr('Copy API key', '复制 API Key')} aria-label={tr('Copy API key', '复制 API Key')}><Icon name="copy" size={14}/></button></div></label>
+      <label className="provider-form-wide"><span>API Key</span><div className="provider-secret-input"><input aria-label="API Key" type={showApiKey ? 'text' : 'password'} value={displayedApiKey} readOnly={isMaskedReadonly} onKeyDown={onApiKeyKeyDown} onPaste={onApiKeyPaste} onChange={event => onChangeApiKey(event.target.value)} placeholder={draft.hasStoredKey && isMaskedReadonly && !displayedApiKey ? tr('Saved API key', '已保存 API Key') : draft.hasStoredKey ? tr('Enter a new key to replace the stored one', '输入新密钥以替换已保存的密钥') : 'sk-...'}/><button type="button" onClick={onToggleApiKeyVisibility} title={showApiKey ? tr('Hide API key', '隐藏 API Key') : tr('Show API key', '显示 API Key')} aria-label={showApiKey ? tr('Hide API key', '隐藏 API Key') : tr('Show API key', '显示 API Key')}><Icon name="eye" size={14}/></button><button type="button" onClick={onCopyApiKey} title={tr('Copy API key', '复制 API Key')} aria-label={tr('Copy API key', '复制 API Key')}><Icon name="copy" size={14}/></button></div></label>
       <label className="provider-switch"><input type="checkbox" checked={draft.autoDiscover} onChange={event => onChange('autoDiscover', event.target.checked)}/><span><strong>{tr('Automatically fetch models', '自动获取模型')}</strong><small>{tr('When off, only custom model IDs are shown.', '关闭后只显示自定义模型 ID。')}</small></span></label>
       <label className="provider-switch"><input type="checkbox" checked={draft.disabled} onChange={event => onChange('disabled', event.target.checked)}/><span><strong>{tr('Disabled', '禁用')}</strong><small>{tr('Disabled providers disappear from model selection.', '禁用后不会出现在模型选择器中。')}</small></span></label>
       {!draft.autoDiscover && <label className="provider-form-wide"><span>{tr('Custom model IDs', '自定义模型 ID')}</span><textarea value={draft.customModels} onChange={event => onChange('customModels', event.target.value)} placeholder={'gpt-4o\nclaude-3-5-sonnet'} rows={4}/></label>}

--- a/apps/nori-web/test/ProviderSettings.test.ts
+++ b/apps/nori-web/test/ProviderSettings.test.ts
@@ -15,6 +15,7 @@ const PROVIDER: ProviderCatalogItem = {
   type: 'openai',
   base_url: 'https://openrouter.ai/api/v1',
   has_api_key: true,
+  api_key_length: 22,
   status: 'connected',
   auto_discover: true,
   custom_models: [],
@@ -95,19 +96,20 @@ describe('ProviderSettings', () => {
       .toBe('https://api.anthropic.com');
   });
 
-  it('keeps a fixed mask until the eye reveals the real key', async () => {
+  it('keeps a length-matched mask until the eye reveals the real key', async () => {
     const { container } = await renderProviders();
     await openEditor(container);
     const key = apiKeyInput(container);
 
-    expect(key.value).toBe('••••••••');
+    expect(key.value).toBe('•'.repeat(22));
     expect(key.type).toBe('password');
+    expect(key.readOnly).toBe(true);
 
     await act(async () => {
       key.focus();
       await Promise.resolve();
     });
-    expect(key.value).toBe('');
+    expect(key.value).toBe('•'.repeat(22));
     expect(vi.mocked(api.providers.secret)).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -119,6 +121,7 @@ describe('ProviderSettings', () => {
     });
     expect(key.value).toBe('sk-live-secret-key-12345');
     expect(key.type).toBe('text');
+    expect(key.readOnly).toBe(false);
 
     await act(async () => {
       showKeyButton(container).click();

--- a/packages/agent-core/src/services/index.ts
+++ b/packages/agent-core/src/services/index.ts
@@ -123,6 +123,7 @@ export {
   IModelCatalogService,
   ModelNotFoundError,
   ProviderNotFoundError,
+  configuredApiKeyLength,
   modelIdsForProvider,
   toProtocolModel,
   toProtocolProvider,

--- a/packages/agent-core/src/services/modelCatalog/modelCatalog.ts
+++ b/packages/agent-core/src/services/modelCatalog/modelCatalog.ts
@@ -92,6 +92,35 @@ export interface ProviderCredentialState {
   readonly hasOAuthToken: boolean;
 }
 
+export function configuredApiKeyLength(provider: ProviderConfig): number | undefined {
+  const inline = nonEmpty(provider.apiKey);
+  if (inline !== undefined) return inline.length;
+  const env = provider.env;
+  if (env === undefined) return undefined;
+  switch (provider.type) {
+    case 'anthropic':
+      return nonEmpty(env['ANTHROPIC_API_KEY'])?.length;
+    case 'openai':
+    case 'openai_responses':
+      return nonEmpty(env['OPENAI_API_KEY'])?.length;
+    case 'kimi':
+      return nonEmpty(env['KIMI_API_KEY'])?.length;
+    case 'google-genai':
+      return nonEmpty(env['GOOGLE_API_KEY'])?.length;
+    case 'vertexai': {
+      const vertex = nonEmpty(env['VERTEXAI_API_KEY']);
+      if (vertex !== undefined) return vertex.length;
+      return nonEmpty(env['GOOGLE_API_KEY'])?.length;
+    }
+  }
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
 export function toProtocolProvider(
   providerId: string,
   provider: ProviderConfig,
@@ -100,6 +129,7 @@ export function toProtocolProvider(
 ): ProviderCatalogItem {
   const models = modelIdsForProvider(config, providerId);
   const defaultModel = provider.defaultModel ?? globalDefaultForProvider(config, providerId);
+  const apiKeyLength = credential.hasApiKey ? configuredApiKeyLength(provider) : undefined;
   return {
     id: providerId,
     name: provider.name ?? providerId,
@@ -107,6 +137,7 @@ export function toProtocolProvider(
     base_url: provider.baseUrl,
     default_model: defaultModel,
     has_api_key: credential.hasApiKey,
+    api_key_length: apiKeyLength,
     status: provider.disabled
       ? 'error'
       : credential.hasApiKey || credential.hasOAuthToken ? 'connected' : 'unconfigured',

--- a/packages/agent-core/test/services/model-catalog-service.test.ts
+++ b/packages/agent-core/test/services/model-catalog-service.test.ts
@@ -15,6 +15,7 @@ import {
   ModelCatalogService,
   ModelNotFoundError,
   ProviderNotFoundError,
+  configuredApiKeyLength,
   toProtocolModel,
   toProtocolProvider,
 } from '../../src/services';
@@ -178,9 +179,19 @@ describe('model catalog adapters', () => {
       base_url: 'https://api.example.test/v1',
       default_model: 'k2',
       has_api_key: true,
+      api_key_length: 7,
       status: 'connected',
       models: ['k2', 'turbo'],
     });
+  });
+
+  it('reports configured API key length from inline and env values', () => {
+    expect(configuredApiKeyLength({ type: 'openai', apiKey: 'sk-test' })).toBe(7);
+    expect(configuredApiKeyLength({
+      type: 'openai',
+      env: { OPENAI_API_KEY: 'env-key' },
+    })).toBe(7);
+    expect(configuredApiKeyLength({ type: 'openai' })).toBeUndefined();
   });
 });
 

--- a/packages/protocol/src/modelCatalog.ts
+++ b/packages/protocol/src/modelCatalog.ts
@@ -27,6 +27,7 @@ export const providerCatalogItemSchema = z.object({
   base_url: z.string().min(1).optional(),
   default_model: z.string().min(1).optional(),
   has_api_key: z.boolean(),
+  api_key_length: z.number().int().min(1).optional(),
   status: providerCatalogStatusSchema,
   disabled: z.boolean().optional(),
   auto_discover: z.boolean().optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issue

Resolve SUD-20

## Problem

In the Provider settings UI, the hidden API Key field always showed eight mask dots regardless of the real key length. Focusing the field also cleared the mask immediately, which made it hard to view, copy, or edit the stored key without accidentally wiping the field.

## What changed

- Added `api_key_length` to the provider catalog API so the web UI can render a length-accurate mask without exposing the secret.
- Kept the masked API Key input read-only on focus; editing now starts only when the user types, pastes, or clicks the reveal/copy controls.
- Updated Provider settings tests to cover the new mask and focus behavior.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SUD-20](https://linear.app/sudden/issue/SUD-20/provider-界面-api-key-显示异常且点击后被清空)

<div><a href="https://cursor.com/agents/bc-f8919df6-e972-415a-9ca2-5a9ee8acd92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8919df6-e972-415a-9ca2-5a9ee8acd92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

