### PR TITLE
feat: add memory edit, swarm running status, and expandable tool details

### DIFF
--- a/.changeset/add-nori-memory-edit.md
+++ b/.changeset/add-nori-memory-edit.md
@@ -1,0 +1,5 @@
+---
+"nori-code": minor
+---
+
+Add nori_memory_edit to update a vault note in place, and show each matching note's write time in memory search. Call nori_memory_edit with the note title to update it in place.

--- a/.changeset/add-vault-note-update-api.md
+++ b/.changeset/add-vault-note-update-api.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Add a vault note update API so existing memory notes can be saved from the web UI.

--- a/.changeset/edit-vault-notes-in-web.md
+++ b/.changeset/edit-vault-notes-in-web.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Let the web memory vault show note write times and edit existing notes from the note detail view.

--- a/.changeset/fix-session-model-auth-gate.md
+++ b/.changeset/fix-session-model-auth-gate.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Use the conversation's selected model when sending if no global default is set, and pick a default after adding a provider.

--- a/.changeset/fix-swarm-activity-badge.md
+++ b/.changeset/fix-swarm-activity-badge.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Count paused swarm agents in the web collaboration badge, without treating queued work as active.

--- a/.changeset/fix-swarm-agent-running-status.md
+++ b/.changeset/fix-swarm-agent-running-status.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Show spawned and resumed swarm agents as running instead of waiting.

--- a/.changeset/fix-web-edit-diff-stats.md
+++ b/.changeset/fix-web-edit-diff-stats.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Show Edit tool +added -removed counts from the recorded diff, pinned next to the file path.

--- a/.changeset/show-web-tool-call-details.md
+++ b/.changeset/show-web-tool-call-details.md
@@ -1,0 +1,5 @@
+---
+"nori-code": patch
+---
+
+Let web chat tool calls expand to show details, and render Edit diffs without original-line placeholders.

--- a/.changeset/show-web-tool-call-details.md
+++ b/.changeset/show-web-tool-call-details.md
@@ -2,4 +2,4 @@
 "nori-code": patch
 ---
 
-Let web chat tool calls expand to show details, and render Edit diffs without original-line placeholders.
+Expand every web chat tool call to show its full input and output. Edit diffs omit original-line placeholders.

--- a/apps/nori-web/src/App.tsx
+++ b/apps/nori-web/src/App.tsx
@@ -159,8 +159,8 @@ export function App() {
     sessions: tr('Sessions', '会话'),
     files: tr('Files', '文件'),
   };
-  const { messages, messagesLoading, isStreaming, currentStreaming, currentThinking, currentWorkBlocks, sessionStatus, compacting, pendingApprovals, pendingQuestions, pendingMcpElicitations, queuedPrompts, todos, codeChanges, resolveApproval, resolveQuestion, dismissQuestion, resolveMcpElicitation, sendMessage, cancelQueuedPrompt, rewindToPrompt, refreshMessages, abort } = useChatMessages(sessionId, activeSession?.title);
-  const activeAgentCount = countActiveAgents([], allSwarmRuns, backgroundTasks.tasks);
+  const { messages, messagesLoading, isStreaming, currentStreaming, currentThinking, currentWorkBlocks, sessionStatus, compacting, pendingApprovals, pendingQuestions, pendingMcpElicitations, queuedPrompts, todos, activeSubagentIds, codeChanges, resolveApproval, resolveQuestion, dismissQuestion, resolveMcpElicitation, sendMessage, cancelQueuedPrompt, rewindToPrompt, refreshMessages, abort } = useChatMessages(sessionId, activeSession?.title);
+  const activeAgentCount = countActiveAgents(activeSubagentIds, allSwarmRuns, backgroundTasks.tasks);
   const hasSwarmActivity = activeSwarmRuns.length > 0 || activeAgentCount > 0;
 
   useEffect(() => {

--- a/apps/nori-web/src/api/client.ts
+++ b/apps/nori-web/src/api/client.ts
@@ -805,6 +805,12 @@ export function createClient(
           undefined,
           { signal },
         ),
+      update: (noteId: string, content: string) =>
+        request<Note & { content: string } | null>(
+          `/vault/notes/${encodeURIComponent(noteId)}`,
+          undefined,
+          { method: 'POST', body: { content } },
+        ),
     },
 
     // --- Swarm ---

--- a/apps/nori-web/src/api/client.ts
+++ b/apps/nori-web/src/api/client.ts
@@ -510,6 +510,7 @@ export interface PromptExecutionOptions {
   goalObjective?: string;
   swarmMode?: boolean;
   loopMode?: boolean;
+  model?: string;
 }
 
 export interface PromptListResponse {
@@ -888,6 +889,7 @@ export function createClient(
               goal_objective: options.goalObjective,
               swarm_mode: options.swarmMode,
               loop_mode: options.loopMode,
+              model: options.model,
               content: [
                 ...(text ? [{ type: 'text' as const, text }] : []),
                 ...attachments.map(attachment => attachment.kind === 'image'
@@ -1262,6 +1264,7 @@ export function createClient(
             goal_objective: options.goalObjective,
             swarm_mode: options.swarmMode,
             loop_mode: options.loopMode,
+            model: options.model,
             content: [
               ...(text ? [{ type: 'text' as const, text }] : []),
               ...attachments.map(attachment => attachment.kind === 'image'

--- a/apps/nori-web/src/components/ChatView.tsx
+++ b/apps/nori-web/src/components/ChatView.tsx
@@ -1049,9 +1049,11 @@ function CompactToolCall({ tool, approvalRequest, codeChanges = [] }: { tool: To
       <span className="compact-tool-icon"><Icon name={toolCallIcon(tool.name)} size={12}/></span>
       <span className="compact-tool-copy"><strong>{tool.name}</strong>{summary && <span>{summary}</span>}</span>
       <small className={statusClass}>{statusLabel}</small>
-      {hasDetails && <Icon className="tool-call-chevron" name="chevron-right" size={11}/>}
+      <Icon className="tool-call-chevron" name="chevron-right" size={11}/>
     </summary>
-    {hasDetails && <ToolCallDetailBody tool={tool} recordedDiff={recordedDiff}/>}
+    {hasDetails
+      ? <ToolCallDetailBody tool={tool} recordedDiff={recordedDiff}/>
+      : <div className="tool-call-detail-body"><section className="tool-call-detail-section tool-call-detail-pre"><pre>{tool.result === undefined ? tr('Waiting for this tool to finish…', '正在等待此工具完成…') : tr('No extra detail for this call.', '这次调用没有更多详情。')}</pre></section></div>}
   </details>;
 }
 
@@ -1136,6 +1138,9 @@ function summarizeToolCall(tool: ToolCall, tr: (english: string, chinese: string
   const args = typeof tool.args === 'object' && tool.args !== null ? tool.args as Record<string, unknown> : {};
   const normalized = tool.name.toLowerCase();
   const path = firstString(args.path, args.file_path, args.filename, args.file);
+  if (normalized === 'nori_memory_edit' || normalized === 'nori_memory_write') {
+    return firstString(args.title) ?? '';
+  }
   if (normalized === 'edit' || normalized === 'write') {
     const resultCounts = diffCounts(tool.result);
     const operationCounts = normalized === 'edit'

--- a/apps/nori-web/src/components/ChatView.tsx
+++ b/apps/nori-web/src/components/ChatView.tsx
@@ -225,7 +225,12 @@ export function ChatView(props: ChatViewProps) {
   const activeMainWriteOverride = mainWriteOverrideSessionRef.current === currentSessionId ? mainWriteOverride : null;
   const runtimeModelValue = sessionStatus?.model?.trim();
   const runtimeModelId = runtimeModelValue === '' ? undefined : runtimeModelValue;
-  const selectedModelId = activeModelOverride ?? runtimeModelId ?? session?.agent_config?.model ?? draftAgentConfig?.model ?? '';
+  const selectedModelId = configuredModelId(
+    activeModelOverride,
+    runtimeModelId,
+    session?.agent_config?.model,
+    draftAgentConfig?.model,
+  );
   const selectedModel = models.find(model => model.model === selectedModelId);
   const thinkingOptions = modelThinkingOptions(selectedModel);
   const selectedThinking = session?.agent_config?.thinking ?? draftAgentConfig?.thinking ?? thinkingOptions.defaultValue;
@@ -550,9 +555,10 @@ export function ChatView(props: ChatViewProps) {
     if (behavior === 'steer') setSteering(true);
     try {
       const promptAttachments = attachments.map(item => item.attachment);
-      const accepted = loopEnabled
-        ? await onSendMessage(text, promptAttachments, behavior, { loopMode: true })
-        : await onSendMessage(text, promptAttachments, behavior);
+      const accepted = await onSendMessage(text, promptAttachments, behavior, {
+        loopMode: loopEnabled ? true : undefined,
+        model: selectedModelId,
+      });
       if (accepted !== false) {
         setInput('');
         setAttachments([]);
@@ -1156,6 +1162,14 @@ function summarizeToolCall(tool: ToolCall, tr: (english: string, chinese: string
 
 function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function configuredModelId(...values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return '';
 }
 
 async function readImageAttachment(file: File): Promise<ComposerAttachment> {

--- a/apps/nori-web/src/components/ChatView.tsx
+++ b/apps/nori-web/src/components/ChatView.tsx
@@ -16,8 +16,7 @@ import { SkillPicker } from './SkillPicker';
 import { UsageOverview } from './UsageOverview';
 import { detectImageMime, isLikelyImageFile } from '../utils/image-mime';
 import { ToolCallDetailBody } from './ToolCallDetailBody';
-import { editLineOperationStats } from '../utils/edit-line-ops';
-import { buildToolCallDetailSections, isToolCallFailed } from '../utils/tool-call-detail';
+import { buildToolCallDetailSections, isToolCallFailed, toolCallChangeStats } from '../utils/tool-call-detail';
 
 export interface ChatViewProps {
   session: Session | null;
@@ -1035,6 +1034,7 @@ function CompactToolCall({ tool, approvalRequest, codeChanges = [] }: { tool: To
   const recordedDiff = tool.id ? codeChanges.find(change => change.operationId === tool.id)?.diff : undefined;
   const detailOptions = recordedDiff !== undefined ? { recordedDiff } : undefined;
   const summary = summarizeToolCall(tool, tr);
+  const changeStats = toolCallChangeStats(tool, recordedDiff);
   const failed = isToolCallFailed(tool.name, tool.result);
   const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;
   const statusLabel = tool.result === undefined
@@ -1048,6 +1048,7 @@ function CompactToolCall({ tool, approvalRequest, codeChanges = [] }: { tool: To
     <summary>
       <span className="compact-tool-icon"><Icon name={toolCallIcon(tool.name)} size={12}/></span>
       <span className="compact-tool-copy"><strong>{tool.name}</strong>{summary && <span>{summary}</span>}</span>
+      {changeStats !== undefined && <span className="compact-tool-diff-stats" aria-label={`+${String(changeStats.additions)} -${String(changeStats.deletions)}`}><b>+{changeStats.additions}</b><i>-{changeStats.deletions}</i></span>}
       <small className={statusClass}>{statusLabel}</small>
       <Icon className="tool-call-chevron" name="chevron-right" size={11}/>
     </summary>
@@ -1142,13 +1143,7 @@ function summarizeToolCall(tool: ToolCall, tr: (english: string, chinese: string
     return firstString(args.title) ?? '';
   }
   if (normalized === 'edit' || normalized === 'write') {
-    const resultCounts = diffCounts(tool.result);
-    const operationCounts = normalized === 'edit'
-      ? editLineOperationStats(args.line_ops)
-      : { additions: countLines(firstString(args.content) ?? ''), deletions: 0 };
-    const additions = resultCounts?.additions ?? operationCounts.additions;
-    const deletions = resultCounts?.deletions ?? operationCounts.deletions;
-    return [path, `+${additions} -${deletions}`].filter(Boolean).join(' · ');
+    return path ?? '';
   }
   if (normalized === 'agentswarm' || normalized === 'agent_swarm') {
     const tasks = Array.isArray(args.tasks) ? args.tasks : Array.isArray(args.items) ? args.items : [];
@@ -1161,22 +1156,6 @@ function summarizeToolCall(tool: ToolCall, tr: (english: string, chinese: string
 
 function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === 'string' && value.length > 0);
-}
-
-function countLines(value: string): number {
-  if (!value) return 0;
-  return value.split(/\r?\n/).length;
-}
-
-function diffCounts(value: string | undefined): { additions: number; deletions: number } | undefined {
-  if (!value?.includes('\n')) return undefined;
-  let additions = 0;
-  let deletions = 0;
-  for (const line of value.split(/\r?\n/)) {
-    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
-    if (line.startsWith('-') && !line.startsWith('---')) deletions++;
-  }
-  return additions > 0 || deletions > 0 ? { additions, deletions } : undefined;
 }
 
 async function readImageAttachment(file: File): Promise<ComposerAttachment> {

--- a/apps/nori-web/src/components/ProviderSettings.tsx
+++ b/apps/nori-web/src/components/ProviderSettings.tsx
@@ -238,22 +238,30 @@ export function ProviderSettings() {
       const models: Record<string, unknown> = {};
       const currentConfig = await api.getConfig();
       const previousProviderId = draft.originalId ?? id;
-      for (const [modelId, alias] of Object.entries(currentConfig.models ?? {})) {
-        if (isModelAliasRecord(alias) && alias.provider === previousProviderId) {
-          models[modelId] = null;
+      const renamed = draft.originalId !== null && draft.originalId !== id;
+      // Auto-discovery replaces aliases on refresh. Wiping them first leaves
+      // an empty catalog if refresh fails, and leftover custom IDs from a
+      // hidden textarea must not be written back as aliases.
+      if (!draft.autoDiscover || renamed) {
+        for (const [modelId, alias] of Object.entries(currentConfig.models ?? {})) {
+          if (isModelAliasRecord(alias) && alias.provider === previousProviderId) {
+            models[modelId] = null;
+          }
         }
       }
-      for (const model of customModels) {
-        models[`${id}/${model}`] = {
-          provider: id,
-          model,
-          max_context_size: 128000,
-          capabilities: ['tool_use'],
-          display_name: model,
-        };
+      if (!draft.autoDiscover) {
+        for (const model of customModels) {
+          models[`${id}/${model}`] = {
+            provider: id,
+            model,
+            max_context_size: 128000,
+            capabilities: ['tool_use'],
+            display_name: model,
+          };
+        }
       }
       await api.updateConfig({ providers: { [id]: providerPatch }, ...(Object.keys(models).length > 0 ? { models } : {}) });
-      if (draft.originalId !== null && draft.originalId !== id) await api.providers.remove(draft.originalId);
+      if (renamed) await api.providers.remove(previousProviderId);
       if (draft.autoDiscover && !draft.disabled) {
         const result = await api.providers.refresh(id);
         const failures = refreshFailures(result);
@@ -267,6 +275,7 @@ export function ProviderSettings() {
       } else {
         setNotice({ text: tr('Provider saved', 'Provider 已保存') });
       }
+      await ensureDefaultModel(id);
       await load();
       window.dispatchEvent(new CustomEvent('nori:model-catalog-changed'));
       setExpandedId(id);
@@ -455,6 +464,23 @@ function isProviderType(value: string): value is ProviderType {
 
 function isModelAliasRecord(value: unknown): value is { provider?: unknown } {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function ensureDefaultModel(providerId: string): Promise<void> {
+  const latest = await api.getConfig();
+  const currentDefault = typeof latest.default_model === 'string' ? latest.default_model.trim() : '';
+  if (currentDefault !== '') return;
+  const firstAlias = firstModelAliasForProvider(latest.models, providerId);
+  if (firstAlias === undefined) return;
+  await api.updateConfig({ default_model: firstAlias });
+}
+
+function firstModelAliasForProvider(models: unknown, providerId: string): string | undefined {
+  if (models === null || typeof models !== 'object' || Array.isArray(models)) return undefined;
+  for (const [modelId, alias] of Object.entries(models as Record<string, unknown>)) {
+    if (isModelAliasRecord(alias) && alias.provider === providerId) return modelId;
+  }
+  return undefined;
 }
 
 function isProviderTestResponse(value: unknown): value is ProviderTestResponse {

--- a/apps/nori-web/src/components/SwarmPanel.tsx
+++ b/apps/nori-web/src/components/SwarmPanel.tsx
@@ -448,11 +448,12 @@ export function runningSwarmAgents(runs: readonly SwarmStatus[]): { ids: Set<str
   let untracked = 0;
   for (const run of runs) {
     if (!run.tasks) {
-      if (swarmRunProgress(run).running) untracked++;
+      const progress = swarmRunProgress(run);
+      if (progress.running || progress.status === 'paused') untracked++;
       continue;
     }
     for (const task of run.tasks) {
-      if (task.status === 'running') ids.add(task.agent_id ?? task.id);
+      if (task.status === 'running' || task.status === 'paused') ids.add(task.agent_id ?? task.id);
     }
   }
   return { ids, untracked };

--- a/apps/nori-web/src/components/VaultBrowser.tsx
+++ b/apps/nori-web/src/components/VaultBrowser.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { api, type Note } from '../api/client';
 import { useVaultNotes } from '../hooks/useApi';
-import { useI18n } from '../i18n';
+import { useI18n, type Locale } from '../i18n';
 import { Icon } from './Icon';
 import { VaultGraph } from './VaultGraph';
 import { MarkdownView } from './MarkdownView';
@@ -16,21 +16,29 @@ const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
 const FOLDERS = ['all', 'analysis', 'decision', 'review', 'task'] as const;
 
 export function VaultBrowser({ mode = 'list' }: { mode?: 'list' | 'graph' }) {
-  const { tr } = useI18n();
+  const { locale, tr } = useI18n();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFolder, setSelectedFolder] = useState<string>('all');
   const [selectedNote, setSelectedNote] = useState<Note | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const { notes, loading, error, refresh } = useVaultNotes();
 
   useEffect(() => {
     setSelectedNote(null);
     setDetailError(null);
+    setEditing(false);
+    setSaveError(null);
   }, [selectedFolder]);
 
   const openNote = useCallback(async (note: Note) => {
     setSelectedNote(note);
+    setEditing(false);
+    setSaveError(null);
     setDetailLoading(true);
     setDetailError(null);
     try {
@@ -44,6 +52,30 @@ export function VaultBrowser({ mode = 'list' }: { mode?: 'list' | 'graph' }) {
     }
   }, [tr]);
 
+  const startEditing = useCallback(() => {
+    if (!selectedNote) return;
+    setDraft(selectedNote.content ?? selectedNote.preview);
+    setSaveError(null);
+    setEditing(true);
+  }, [selectedNote]);
+
+  const saveNote = useCallback(async () => {
+    if (!selectedNote) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await api.vault.update(selectedNote.path || selectedNote.title, draft);
+      if (!updated) throw new Error(tr('The note no longer exists.', '这篇笔记已不存在。'));
+      setSelectedNote(updated);
+      setEditing(false);
+      await refresh();
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : tr('Failed to save note.', '保存笔记失败。'));
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, refresh, selectedNote, tr]);
+
   const filteredNotes = notes.filter(note => {
     const query = searchQuery.toLowerCase();
     return (selectedFolder === 'all' || note.folder === selectedFolder) &&
@@ -56,15 +88,28 @@ export function VaultBrowser({ mode = 'list' }: { mode?: 'list' | 'graph' }) {
     return (
       <div className="card vault-note-detail">
         <div className="vault-note-toolbar">
-          <button className="btn" onClick={() => setSelectedNote(null)}><Icon name="chevron-left" size={14} /> {tr('Back', '返回')}</button>
+          <button className="btn" onClick={() => { setEditing(false); setSelectedNote(null); }}><Icon name="chevron-left" size={14} /> {tr('Back', '返回')}</button>
+          {!detailLoading && !detailError && (editing
+            ? <span className="vault-note-actions">
+              <button className="btn" onClick={() => setEditing(false)} disabled={saving}>{tr('Cancel', '取消')}</button>
+              <button className="btn btn-primary" onClick={() => void saveNote()} disabled={saving || draft.trim().length === 0}>
+                {saving ? tr('Saving…', '正在保存…') : tr('Save', '保存')}
+              </button>
+            </span>
+            : <button className="btn" onClick={startEditing}>{tr('Edit', '编辑')}</button>)}
         </div>
         <span className="vault-note-type" style={{ background: typeColors.bg, color: typeColors.color }}>{selectedNote.type}</span>
         <h2>{selectedNote.title}</h2>
-        <div className="vault-note-date">{selectedNote.date}</div>
+        <div className="vault-note-date">{formatVaultTimestamp(selectedNote.date, locale)}</div>
         {detailLoading ? (
           <div className="vault-note-state"><span className="spinner spinner-small" /> {tr('Loading full note', '正在加载完整笔记')}</div>
         ) : detailError ? (
           <div className="vault-note-state error">{detailError}</div>
+        ) : editing ? (
+          <>
+            <textarea className="vault-note-editor" value={draft} onChange={event => setDraft(event.target.value)} spellCheck={false} />
+            {saveError && <div className="vault-note-state error">{saveError}</div>}
+          </>
         ) : (
           <MarkdownView className="vault-note-content" content={noteBodyWithoutDuplicateTitle(selectedNote)} />
         )}
@@ -103,7 +148,7 @@ export function VaultBrowser({ mode = 'list' }: { mode?: 'list' | 'graph' }) {
               <button key={note.path || `${note.type}-${note.title}-${index}`} className="card vault-note-card" onClick={() => void openNote(note)}>
                 <span className="vault-note-card-heading"><strong>{note.title}</strong><span className="vault-note-type" style={{ background: typeColors.bg, color: typeColors.color }}>{note.type}</span></span>
                 <span className="vault-note-preview">{note.preview}</span>
-                <time>{note.date}</time>
+                <time dateTime={note.date}>{formatVaultTimestamp(note.date, locale)}</time>
               </button>
             );
           })}
@@ -155,6 +200,15 @@ function normalizeVaultLink(value: string): string {
     .replace(/^\.\//, '')
     .replace(/\.md$/i, '')
     .toLowerCase();
+}
+
+export function formatVaultTimestamp(value: string, locale: Locale): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return value;
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(parsed));
 }
 
 function noteBodyWithoutDuplicateTitle(note: Note): string {

--- a/apps/nori-web/src/components/WorkspaceInspector.tsx
+++ b/apps/nori-web/src/components/WorkspaceInspector.tsx
@@ -3,7 +3,7 @@ import { api, type FsDiffResponse, type FsGitStatusResponse, type FsReadResponse
 import type { ChatMessage, CodeChange, TodoItem } from '../hooks/useChatMessages';
 import type { GitStatusRefreshOptions } from '../hooks/useFilesystem';
 import { useI18n } from '../i18n';
-import { editLineOperationsDiff } from '../utils/edit-line-ops';
+import { editLineOperationsDiff, isChangedDiffLine } from '../utils/edit-line-ops';
 import { FilePreview } from './FilePreview';
 import { Icon } from './Icon';
 import { LspPanel } from './LspPanel';
@@ -969,15 +969,16 @@ function GitPanel({ sessionId, projectPath, status, error, loading, onRefresh }:
 }
 
 function compactChangedLines(diff: string): string[] {
-  return diff.split('\n').filter(line => (line.startsWith('+') && !line.startsWith('+++')) || (line.startsWith('-') && !line.startsWith('---'))).slice(0, 40);
+  return diff.split('\n').filter(line => isChangedDiffLine(line)).slice(0, 40);
 }
 
 export function changedLineStats(diff: string): { additions: number; deletions: number } {
   let additions = 0;
   let deletions = 0;
   for (const line of diff.split('\n')) {
-    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
-    else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+    if (!isChangedDiffLine(line)) continue;
+    if (line.startsWith('+')) additions++;
+    else if (line.startsWith('-')) deletions++;
   }
   return { additions, deletions };
 }

--- a/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
+++ b/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
@@ -186,7 +186,7 @@ const CODE_CHANGES: CodeChange[] = [
 
 export function EditStatsMockPage() {
   useLayoutEffect(() => {
-    for (const element of document.querySelectorAll('.chat-work-process')) {
+    for (const element of document.querySelectorAll('.chat-work-process, .expandable-tool-call')) {
       if (element instanceof HTMLDetailsElement && !element.open) {
         element.querySelector('summary')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       }

--- a/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
+++ b/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import type { ModelCatalogItem, Session } from '../../api/client';
 import type { ChatMessage, CodeChange, WorkBlock } from '../../hooks/useChatMessages';
 import { ChatView } from '../ChatView';
@@ -185,14 +185,13 @@ const CODE_CHANGES: CodeChange[] = [
 ];
 
 export function EditStatsMockPage() {
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      for (const element of document.querySelectorAll('.chat-work-process')) {
-        if (element instanceof HTMLDetailsElement) element.open = true;
+  useLayoutEffect(() => {
+    for (const element of document.querySelectorAll('.chat-work-process')) {
+      if (element instanceof HTMLDetailsElement && !element.open) {
+        element.querySelector('summary')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       }
-    }, 80);
-    return () => window.clearTimeout(timer);
-  }, []);
+    }
+  });
 
   return <div className="tool-call-detail-mock-page">
     <header className="exit-plan-mock-header">

--- a/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
+++ b/apps/nori-web/src/components/dev/EditStatsMockPage.tsx
@@ -1,0 +1,226 @@
+import { useEffect } from 'react';
+import type { ModelCatalogItem, Session } from '../../api/client';
+import type { ChatMessage, CodeChange, WorkBlock } from '../../hooks/useChatMessages';
+import { ChatView } from '../ChatView';
+
+const MOCK_STARTED_AT = new Date().toISOString();
+
+const SESSION: Session = {
+  id: 'mock-edit-stats-session',
+  title: 'Edit +xx -xx preview',
+  status: 'idle',
+  created_at: MOCK_STARTED_AT,
+  updated_at: MOCK_STARTED_AT,
+  message_count: 2,
+  metadata: { cwd: '/workspace' },
+  agent_config: {
+    model: 'mock/gpt-5.4',
+    thinking: 'high',
+    permission_mode: 'auto',
+    plan_mode: false,
+    main_write_enabled: true,
+  },
+};
+
+const MODELS: ModelCatalogItem[] = [{
+  provider: 'mock',
+  model: 'mock/gpt-5.4',
+  display_name: 'GPT-5.4 Mock',
+  max_context_size: 200_000,
+  capabilities: ['thinking', 'tool_use'],
+}];
+
+const WORK_BLOCKS: WorkBlock[] = [
+  {
+    id: 'edit-replace-recorded',
+    type: 'tool',
+    tool: {
+      id: 'edit-replace-recorded',
+      name: 'Edit',
+      args: {
+        path: 'apps/nori-web/src/components/ChatView.tsx',
+        expected_tag: 'A1B2',
+        line_ops: [{
+          op: 'swap',
+          start: 42,
+          end: 46,
+          content: [
+            'const summary = summarizeToolCall(tool, tr);',
+            'const recordedDiff = tool.id ? codeChanges.find(change => change.operationId === tool.id)?.diff : undefined;',
+            'const failed = isToolCallFailed(tool.name, tool.result);',
+            'const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;',
+            'const statusLabel = tool.result === undefined ? tr("Running", "运行中") : tr("Done", "完成");',
+          ].join('\n'),
+        }],
+      },
+      result: '[apps/nori-web/src/components/ChatView.tsx#C3D4]\nApplied 1 line operation to apps/nori-web/src/components/ChatView.tsx.',
+    },
+  },
+  {
+    id: 'edit-insert',
+    type: 'tool',
+    tool: {
+      id: 'edit-insert',
+      name: 'Edit',
+      args: {
+        path: 'src/auth/session.ts',
+        expected_tag: '11AA',
+        line_ops: [{
+          op: 'insert_post',
+          line: 8,
+          content: 'export function restoreSession() {\n  return readStoredToken();\n}\n',
+        }],
+      },
+      result: '[src/auth/session.ts#22BB]\nApplied 1 line operation to src/auth/session.ts.',
+    },
+  },
+  {
+    id: 'edit-delete',
+    type: 'tool',
+    tool: {
+      id: 'edit-delete',
+      name: 'Edit',
+      args: {
+        path: 'src/legacy/unused.ts',
+        expected_tag: '33CC',
+        line_ops: [{ op: 'del', start: 10, end: 12 }],
+      },
+      result: '[src/legacy/unused.ts#44DD]\nApplied 1 line operation to src/legacy/unused.ts.',
+    },
+  },
+  {
+    id: 'edit-placeholder',
+    type: 'tool',
+    tool: {
+      id: 'edit-placeholder',
+      name: 'Edit',
+      args: {
+        path: 'apps/nori-web/src/styles/nori-theme.css',
+        expected_tag: '55EE',
+        line_ops: [{ op: 'swap', start: 1, end: 1, content: 'background:#050510;' }],
+      },
+      result: '[apps/nori-web/src/styles/nori-theme.css#66FF]\nApplied 1 line operation to apps/nori-web/src/styles/nori-theme.css.',
+    },
+  },
+  {
+    id: 'edit-ops-only',
+    type: 'tool',
+    tool: {
+      id: 'edit-ops-only',
+      name: 'Edit',
+      args: {
+        path: 'src/utils/format.ts',
+        expected_tag: '77AA',
+        line_ops: [{ op: 'swap', start: 4, end: 4, content: 'export function pad(value: string): string {\n  return value.padStart(2, "0");}' }],
+      },
+      result: '[src/utils/format.ts#88BB]\nApplied 1 line operation to src/utils/format.ts.',
+    },
+  },
+];
+
+const MESSAGES: ChatMessage[] = [
+  {
+    id: 'mock-user-message',
+    role: 'user',
+    text: '核对 Edit 工具行上的 +xx -xx 是否和真实改动一致。',
+    createdAt: MOCK_STARTED_AT,
+  },
+  {
+    id: 'mock-assistant-message',
+    role: 'assistant',
+    text: '已用 recorded diff 统计增删行；没有 diff 时回退到 line_ops。',
+    workBlocks: WORK_BLOCKS,
+    createdAt: new Date(Date.now() + 8_000).toISOString(),
+  },
+];
+
+const CODE_CHANGES: CodeChange[] = [
+  {
+    operationId: 'edit-replace-recorded',
+    agentId: 'main',
+    operation: 'edit',
+    path: 'apps/nori-web/src/components/ChatView.tsx',
+    diff: [
+      '-const failed = isToolCallFailed(tool.name, tool.result);',
+      '-const hasDetails = buildToolCallDetailSections(tool).length > 0;',
+      '+const recordedDiff = tool.id ? codeChanges.find(change => change.operationId === tool.id)?.diff : undefined;',
+      '+const failed = isToolCallFailed(tool.name, tool.result);',
+      '+const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;',
+    ].join('\n'),
+    occurredAt: MOCK_STARTED_AT,
+  },
+  {
+    operationId: 'edit-insert',
+    agentId: 'main',
+    operation: 'edit',
+    path: 'src/auth/session.ts',
+    diff: [
+      '+export function restoreSession() {',
+      '+  return readStoredToken();',
+      '+}',
+      '+',
+    ].join('\n'),
+    occurredAt: MOCK_STARTED_AT,
+  },
+  {
+    operationId: 'edit-delete',
+    agentId: 'main',
+    operation: 'edit',
+    path: 'src/legacy/unused.ts',
+    diff: [
+      '-export const leftover = true;',
+      '-export const staleFlag = false;',
+      '-export const unusedHelper = () => undefined;',
+    ].join('\n'),
+    occurredAt: MOCK_STARTED_AT,
+  },
+  {
+    operationId: 'edit-placeholder',
+    agentId: 'main',
+    operation: 'edit',
+    path: 'apps/nori-web/src/styles/nori-theme.css',
+    diff: '- [original line 1 replaced]\n+background:#050510;',
+    occurredAt: MOCK_STARTED_AT,
+  },
+];
+
+export function EditStatsMockPage() {
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      for (const element of document.querySelectorAll('.chat-work-process')) {
+        if (element instanceof HTMLDetailsElement) element.open = true;
+      }
+    }, 80);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return <div className="tool-call-detail-mock-page">
+    <header className="exit-plan-mock-header">
+      <span className="exit-plan-mock-brand">Nori Work</span>
+      <strong>Edit +xx -xx</strong>
+      <span className="exit-plan-mock-status">ChatView +3 -2 · insert +4 -0 · delete +0 -3 · placeholder +1 -1 · ops-only +2 -1</span>
+    </header>
+    <main className="exit-plan-mock-content">
+      <ChatView
+        session={SESSION}
+        messages={MESSAGES}
+        streaming=""
+        thinking=""
+        isStreaming={false}
+        models={MODELS}
+        modelsLoading={false}
+        modelError={null}
+        onSendMessage={() => false}
+        onAbort={() => false}
+        onRefreshModels={() => undefined}
+        onModelChange={() => undefined}
+        onThinkingChange={() => undefined}
+        onPermissionChange={() => undefined}
+        onTaskModeChange={() => undefined}
+        onRunSlashCommand={() => false}
+        onMainWriteChange={() => undefined}
+        codeChanges={CODE_CHANGES}
+      />
+    </main>
+  </div>;
+}

--- a/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
+++ b/apps/nori-web/src/components/dev/ToolCallDetailMockPage.tsx
@@ -32,6 +32,39 @@ const MODELS: ModelCatalogItem[] = [{
 
 const WORK_BLOCKS: WorkBlock[] = [
   {
+    id: 'mock-read-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-read-tool',
+      name: 'Read',
+      args: { path: 'src/auth.ts', line_offset: 1 },
+      result: 'export function login(user: string) {\n  return issueToken(user);\n}\n',
+    },
+  },
+  {
+    id: 'mock-grep-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-grep-tool',
+      name: 'Grep',
+      args: { pattern: 'countActiveAgents', path: 'apps/nori-web', glob: '*.ts' },
+      result: 'apps/nori-web/src/App.tsx:593:export function countActiveAgents(\napps/nori-web/test/PrimaryNavigation.test.ts:5:import { countActiveAgents }',
+    },
+  },
+  {
+    id: 'mock-write-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-write-tool',
+      name: 'Write',
+      args: {
+        path: 'notes/auth.md',
+        content: '# Auth\n\nLogin issues a token for the given user.\n',
+      },
+      result: 'Wrote notes/auth.md',
+    },
+  },
+  {
     id: 'mock-edit-tool',
     type: 'tool',
     tool: {
@@ -49,6 +82,39 @@ const WORK_BLOCKS: WorkBlock[] = [
     },
   },
   {
+    id: 'mock-bash-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-bash-tool',
+      name: 'Bash',
+      args: { command: 'pnpm --filter @nori-code/nori-web exec vitest run test/tool-call-detail.test.ts' },
+      result: 'Test Files  1 passed (1)\n      Tests  9 passed (9)',
+    },
+  },
+  {
+    id: 'mock-agent-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-agent-tool',
+      name: 'Agent',
+      args: {
+        subagent_type: 'explore',
+        prompt: 'Find every authentication entry point and summarize the login flow, including token issuance and session restore.',
+      },
+      result: 'Auth entry points: src/auth.ts, src/session.ts. Login issues a token and restores the session from local storage.',
+    },
+  },
+  {
+    id: 'mock-websearch-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-websearch-tool',
+      name: 'WebSearch',
+      args: { query: 'RFC 9110 HTTP semantics cache invalidation' },
+      result: '1. RFC 9110 — HTTP Semantics\n2. Cache invalidation is the responsibility of the origin.',
+    },
+  },
+  {
     id: 'mock-browser-tool',
     type: 'tool',
     tool: {
@@ -62,19 +128,77 @@ const WORK_BLOCKS: WorkBlock[] = [
       result: 'Navigated to https://example.com/docs/api\nTitle: API Reference · Example Docs\nSnapshot: 24 interactive elements, 3 scroll regions.',
     },
   },
+  {
+    id: 'mock-glob-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-glob-tool',
+      name: 'Glob',
+      args: { pattern: '**/*.test.ts', path: 'apps/nori-web' },
+      result: 'apps/nori-web/test/ChatView.test.ts\napps/nori-web/test/tool-call-detail.test.ts',
+    },
+  },
+  {
+    id: 'mock-fetch-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-fetch-tool',
+      name: 'FetchURL',
+      args: { url: 'https://example.com/docs/api' },
+      result: '# API Reference\n\nGET /v1/sessions returns the session list.\nPOST /v1/sessions creates a session.',
+    },
+  },
+  {
+    id: 'mock-mcp-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-mcp-tool',
+      name: 'mcp__github__create_issue',
+      args: {
+        title: 'Fix collaboration badge',
+        body: 'The collaboration badge counted the wrong session.\nCount paused agents too.',
+      },
+      result: 'Created issue #12',
+    },
+  },
+  {
+    id: 'mock-todo-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-todo-tool',
+      name: 'TodoList',
+      args: {
+        todos: [
+          { title: 'Fix collaboration badge', status: 'done' },
+          { title: 'Show every tool payload', status: 'in_progress' },
+        ],
+      },
+      result: 'Current todo list:\n  [done] Fix collaboration badge\n  [in_progress] Show every tool payload',
+    },
+  },
+  {
+    id: 'mock-memory-tool',
+    type: 'tool',
+    tool: {
+      id: 'mock-memory-tool',
+      name: 'nori_memory_search',
+      args: { keywords: ['auth', 'login', 'token'] },
+      result: '[score: 0.91, written: 2026-08-17T00:00:00.000Z] analysis/auth.md\nLogin issues a token and restores the session.',
+    },
+  },
 ];
 
 const MESSAGES: ChatMessage[] = [
   {
     id: 'mock-user-message',
     role: 'user',
-    text: '请修改 ChatView 并打开文档页核对 API 说明。',
+    text: '请修改 ChatView，并核对登录流程、搜索结果和文档页。',
     createdAt: MOCK_STARTED_AT,
   },
   {
     id: 'mock-assistant-message',
     role: 'assistant',
-    text: '已完成代码修改，并在浏览器中打开了文档页面进行核对。',
+    text: '已完成代码修改，并核对了登录流程、搜索结果和文档页面。',
     workBlocks: WORK_BLOCKS,
     createdAt: new Date(Date.now() + 12_000).toISOString(),
   },
@@ -91,8 +215,6 @@ const CODE_CHANGES: CodeChange[] = [{
     '+const summary = summarizeToolCall(tool, tr);',
     '+const failed = isToolCallFailed(tool.name, tool.result);',
     '+const hasDetails = buildToolCallDetailSections(tool, detailOptions).length > 0;',
-    '-',
-    '-',
   ].join('\n'),
   occurredAt: MOCK_STARTED_AT,
 }];
@@ -111,7 +233,7 @@ export function ToolCallDetailMockPage() {
     <header className="exit-plan-mock-header">
       <span className="exit-plan-mock-brand">Nori Work</span>
       <strong>Tool call details</strong>
-      <span className="exit-plan-mock-status">Edit + Browser preview</span>
+      <span className="exit-plan-mock-status">Every tool call expands with its full input and output</span>
     </header>
     <main className="exit-plan-mock-content">
       <ChatView

--- a/apps/nori-web/src/main.tsx
+++ b/apps/nori-web/src/main.tsx
@@ -7,6 +7,7 @@ import { InspectorPopout } from './components/InspectorPopout';
 import type { InspectorTab } from './components/WorkspaceInspector';
 import { ExitPlanModeMockPage } from './components/dev/ExitPlanModeMockPage';
 import { ToolCallDetailMockPage } from './components/dev/ToolCallDetailMockPage';
+import { EditStatsMockPage } from './components/dev/EditStatsMockPage';
 import './styles/nori-theme.css';
 import './styles/linear-flat.css';
 
@@ -18,6 +19,8 @@ const content = import.meta.env.DEV && mockScenario === 'exit-plan-mode'
   ? <ExitPlanModeMockPage />
   : import.meta.env.DEV && mockScenario === 'tool-call-detail'
     ? <ToolCallDetailMockPage />
+  : import.meta.env.DEV && mockScenario === 'edit-stats'
+    ? <EditStatsMockPage />
   : inspector && ['preview', 'changes', 'browser', 'git', 'lsp', 'terminal'].includes(inspector)
   ? <InspectorPopout tab={inspector} sessionId={hashParams.get('session')} path={hashParams.get('path') ?? ''}/>
   : <App />;

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -4371,11 +4371,14 @@ kbd {
 .exit-plan-chevron { color: var(--nori-text-muted); transform: rotate(0deg); transition: transform 160ms ease, color 160ms ease; }
 .exit-plan-tool-call[open] .exit-plan-chevron { color: var(--nori-text-secondary); transform: rotate(90deg); }
 .expandable-tool-call { display: block; min-width: 0; padding: 0; border: 0; border-radius: 0; background: transparent; }
-.expandable-tool-call > summary { display: grid; min-height: 30px; grid-template-columns: 20px minmax(0, 1fr) auto 14px; align-items: center; gap: 7px; padding: 3px 0; cursor: pointer; list-style: none; }
+.expandable-tool-call > summary { display: grid; min-height: 30px; grid-template-columns: 20px minmax(0, 1fr) auto auto 14px; align-items: center; gap: 7px; padding: 3px 0; cursor: pointer; list-style: none; }
 .expandable-tool-call > summary::-webkit-details-marker { display: none; }
 .expandable-tool-call > summary > small.failed { color: var(--nori-danger); }
 .tool-call-chevron { color: var(--nori-text-muted); transform: rotate(0deg); transition: transform 160ms ease, color 160ms ease; }
 .expandable-tool-call[open] .tool-call-chevron { color: var(--nori-text-secondary); transform: rotate(90deg); }
+.compact-tool-diff-stats { display: flex; flex-shrink: 0; align-items: center; gap: 5px; font: calc(9px * var(--nori-ui-font-scale))/1 var(--nori-font-mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.compact-tool-diff-stats b { color: var(--nori-success); font-weight: 650; }
+.compact-tool-diff-stats i { color: var(--nori-danger); font-style: normal; font-weight: 650; }
 .tool-call-detail-body { display: grid; gap: 8px; margin: 4px 0 6px 27px; }
 .tool-call-detail-section { display: grid; gap: 4px; }
 .tool-call-detail-section > header { color: var(--nori-text-muted); font-size: calc(8px * var(--nori-ui-font-scale)); font-weight: 650; text-transform: uppercase; letter-spacing: .04em; }

--- a/apps/nori-web/src/styles/nori-theme.css
+++ b/apps/nori-web/src/styles/nori-theme.css
@@ -2746,7 +2746,19 @@ kbd {
 }
 .vault-note-card time, .vault-note-date { color: var(--nori-text-muted); font-size: calc(9px * var(--nori-ui-font-scale)); }
 .vault-note-detail { display: grid; gap: 12px; width: 100%; padding: 18px; }
-.vault-note-toolbar { display: flex; align-items: center; }
+.vault-note-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.vault-note-actions { display: flex; align-items: center; gap: 8px; }
+.vault-note-editor {
+  min-height: 320px;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--nori-border);
+  border-radius: 8px;
+  background: var(--nori-surface);
+  color: var(--nori-text);
+  font: calc(12px * var(--nori-ui-font-scale))/1.6 var(--nori-font-mono);
+  resize: vertical;
+}
 .vault-note-detail h2 { color: var(--nori-text); font-size: calc(19px * var(--nori-ui-font-scale)); }
 .vault-note-content {
   min-height: 240px;

--- a/apps/nori-web/src/utils/edit-line-ops.ts
+++ b/apps/nori-web/src/utils/edit-line-ops.ts
@@ -69,6 +69,18 @@ export function editOperationLabel(operation: EditLineOperation): string {
   }
 }
 
+const PLACEHOLDER_DIFF_LINE = /^[-+]?\s*\[original line \d+ (?:replaced|deleted)\]\s*$/;
+
+export function isPlaceholderDiffLine(line: string): boolean {
+  return PLACEHOLDER_DIFF_LINE.test(line);
+}
+
+export function isChangedDiffLine(line: string): boolean {
+  if (isPlaceholderDiffLine(line)) return false;
+  return (line.startsWith('+') && !line.startsWith('+++'))
+    || (line.startsWith('-') && !line.startsWith('---'));
+}
+
 export function editLineOperationsDiff(value: unknown): string[] {
   const lines: string[] = [];
   for (const operation of parseEditLineOperations(value)) {

--- a/apps/nori-web/src/utils/edit-line-ops.ts
+++ b/apps/nori-web/src/utils/edit-line-ops.ts
@@ -81,6 +81,18 @@ export function isChangedDiffLine(line: string): boolean {
     || (line.startsWith('-') && !line.startsWith('---'));
 }
 
+export function diffLineStats(diff: string | undefined): { additions: number; deletions: number } | undefined {
+  if (diff === undefined || diff.length === 0) return undefined;
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('+')) additions += 1;
+    else if (line.startsWith('-')) deletions += 1;
+  }
+  return additions > 0 || deletions > 0 ? { additions, deletions } : undefined;
+}
+
 export function editLineOperationsDiff(value: unknown): string[] {
   const lines: string[] = [];
   for (const operation of parseEditLineOperations(value)) {

--- a/apps/nori-web/src/utils/tool-call-detail.ts
+++ b/apps/nori-web/src/utils/tool-call-detail.ts
@@ -1,4 +1,4 @@
-import type { CodeChange, ToolCall } from '../hooks/useChatMessages';
+import type { ToolCall } from '../hooks/useChatMessages';
 import { editLineOperationsDiff, isChangedDiffLine, isPlaceholderDiffLine, parseEditLineOperations } from './edit-line-ops';
 
 export interface ToolCallDetailOptions {
@@ -12,8 +12,51 @@ export interface ToolCallDetailSection {
   readonly text?: string;
 }
 
-const MAX_DIFF_LINES = 80;
 const MAX_PRE_CHARS = 24_000;
+const LIFTED_STRING_CHARS = 120;
+
+interface PayloadField {
+  readonly key: string;
+  readonly label: string;
+}
+
+const PAYLOAD_FIELDS: Record<string, readonly PayloadField[]> = {
+  bash: [{ key: 'command', label: 'Command' }],
+  write: [{ key: 'content', label: 'New content' }],
+  edit: [{ key: 'line_ops', label: 'Line operations' }, { key: 'expected_tag', label: 'Tag' }],
+  read: [{ key: 'path', label: 'Path' }],
+  norimemorywrite: [{ key: 'content', label: 'Content' }],
+  norimemoryedit: [{ key: 'content', label: 'Content' }],
+  noriplanwrite: [{ key: 'content', label: 'Content' }],
+  agent: [{ key: 'prompt', label: 'Prompt' }, { key: 'description', label: 'Description' }],
+  agentswarm: [
+    { key: 'prompt_template', label: 'Template' },
+    { key: 'tasks', label: 'Tasks' },
+    { key: 'items', label: 'Items' },
+  ],
+  agentswarmcontrol: [{ key: 'prompt', label: 'Prompt' }],
+  skill: [{ key: 'args', label: 'Arguments' }],
+  todolist: [{ key: 'todos', label: 'Todos' }],
+  askuserquestion: [{ key: 'questions', label: 'Questions' }],
+  websearch: [{ key: 'query', label: 'Query' }],
+  fetchurl: [{ key: 'url', label: 'URL' }],
+  grep: [{ key: 'pattern', label: 'Pattern' }],
+  glob: [{ key: 'pattern', label: 'Pattern' }],
+  norimemorysearch: [{ key: 'keywords', label: 'Keywords' }],
+  norimemoryremove: [{ key: 'title', label: 'Title' }],
+  noriaskparent: [{ key: 'question', label: 'Question' }, { key: 'context', label: 'Context' }],
+  noriswarmlaunch: [{ key: 'params', label: 'Params' }],
+  croncreate: [{ key: 'prompt', label: 'Prompt' }],
+  creategoal: [
+    { key: 'objective', label: 'Objective' },
+    { key: 'completionCriterion', label: 'Completion criterion' },
+  ],
+  browser: [
+    { key: 'text', label: 'Text' },
+    { key: 'prompt_text', label: 'Prompt' },
+    { key: 'paths', label: 'Paths' },
+  ],
+};
 
 function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -27,6 +70,10 @@ function firstString(...values: unknown[]): string | undefined {
 
 function normalizeToolName(name: string): string {
   return name.replaceAll(/[-_\s]/g, '').toLowerCase();
+}
+
+function payloadFieldsFor(normalized: string): readonly PayloadField[] {
+  return PAYLOAD_FIELDS[normalized] ?? [];
 }
 
 export function isToolCallFailed(name: string, result: string | undefined): boolean {
@@ -49,11 +96,18 @@ function writeContentDiff(content: unknown): string {
 }
 
 function compactDiffLines(diff: string): string[] {
-  const lines = diff.split('\n').filter(line =>
-    line.startsWith('@@') || isChangedDiffLine(line),
-  );
-  if (lines.length <= MAX_DIFF_LINES) return lines;
-  return [...lines.slice(0, MAX_DIFF_LINES), `... ${String(lines.length - MAX_DIFF_LINES)} more changed lines`];
+  const lines = diff.split('\n').filter(line => !isPlaceholderDiffLine(line));
+  let total = 0;
+  const kept: string[] = [];
+  for (const line of lines) {
+    if (total + line.length + 1 > MAX_PRE_CHARS) {
+      kept.push(`... ${String(lines.length - kept.length)} more lines`);
+      break;
+    }
+    kept.push(line);
+    total += line.length + 1;
+  }
+  return kept;
 }
 
 function hasTextDiff(diff: string): boolean {
@@ -101,32 +155,62 @@ function truncatePre(text: string): string {
   return `${text.slice(0, MAX_PRE_CHARS)}\n... truncated`;
 }
 
-function formatArgsSummary(tool: ToolCall, excludeKeys: Set<string>): string | undefined {
-  const args = asRecord(tool.args);
-  const entries = Object.entries(args).filter(([key, value]) => {
-    if (excludeKeys.has(key)) return false;
-    if (value === undefined || value === null) return false;
-    if (typeof value === 'string' && value.length === 0) return false;
-    return true;
-  });
+function formatArgValue(value: unknown): string {
+  if (typeof value === 'string') return truncatePre(value);
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized === undefined ? '[unserializable]' : truncatePre(serialized);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+function isPresent(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function shouldLiftValue(value: unknown): boolean {
+  if (typeof value === 'string') return value.length >= LIFTED_STRING_CHARS || value.includes('\n');
+  if (Array.isArray(value)) return value.length > 0;
+  return typeof value === 'object' && value !== null;
+}
+
+function titleCaseKey(key: string): string {
+  const spaced = key.replaceAll(/[_-]+/g, ' ').trim();
+  if (spaced.length === 0) return key;
+  return spaced.replaceAll(/\b\w/g, char => char.toUpperCase());
+}
+
+function formatArgsBlock(args: Record<string, unknown>, excludeKeys: Set<string>): string | undefined {
+  const entries = Object.entries(args).filter(([key, value]) => !excludeKeys.has(key) && isPresent(value));
   if (entries.length === 0) return undefined;
 
   const lines: string[] = [];
   for (const [key, value] of entries) {
-    if (typeof value === 'string') {
-      const preview = value.length > 240 ? `${value.slice(0, 240)}…` : value;
-      lines.push(`${key}: ${preview}`);
+    if (typeof value === 'string' && !value.includes('\n')) {
+      lines.push(`${key}: ${truncatePre(value)}`);
       continue;
     }
-    try {
-      const serialized = JSON.stringify(value);
-      const preview = serialized.length > 240 ? `${serialized.slice(0, 240)}…` : serialized;
-      lines.push(`${key}: ${preview}`);
-    } catch {
-      lines.push(`${key}: [unserializable]`);
-    }
+    const formatted = formatArgValue(value);
+    lines.push(formatted.includes('\n') ? `${key}:\n${formatted}` : `${key}: ${formatted}`);
   }
   return lines.join('\n');
+}
+
+function resultLabel(normalized: string): string {
+  if (normalized === 'bash') return 'Output';
+  if (normalized === 'read') return 'File';
+  if (normalized === 'grep') return 'Matches';
+  if (normalized === 'glob') return 'Files';
+  if (normalized === 'websearch') return 'Results';
+  if (normalized === 'fetchurl') return 'Page';
+  if (normalized === 'browser') return 'Snapshot';
+  if (normalized === 'skill') return 'Skill output';
+  if (normalized === 'taskoutput') return 'Task output';
+  return 'Result';
 }
 
 export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDetailOptions): ToolCallDetailSection[] {
@@ -135,35 +219,38 @@ export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDe
   const args = asRecord(tool.args);
   const failed = isToolCallFailed(tool.name, tool.result);
   const changeDiff = buildToolCallChangeDiff(tool, options);
+  const payloadFields = payloadFieldsFor(normalized);
 
-  const excludeArgKeys = new Set<string>();
-  if (normalized === 'write') excludeArgKeys.add('content');
-  if (normalized === 'edit') {
-    excludeArgKeys.add('line_ops');
-    excludeArgKeys.add('expected_tag');
-  }
-  if (normalized === 'bash') excludeArgKeys.add('command');
-  if (normalized === 'norimemorywrite' || normalized === 'norimemoryedit') {
-    excludeArgKeys.add('content');
+  const excludeArgKeys = new Set<string>(payloadFields.map(field => field.key));
+  for (const [key, value] of Object.entries(args)) {
+    if (excludeArgKeys.has(key)) continue;
+    if (shouldLiftValue(value)) excludeArgKeys.add(key);
   }
 
-  const argsSummary = formatArgsSummary(tool, excludeArgKeys);
+  const argsSummary = formatArgsBlock(args, excludeArgKeys);
   if (argsSummary !== undefined) {
     sections.push({ kind: 'pre', label: 'Input', text: argsSummary });
   }
 
-  if (normalized === 'norimemorywrite' || normalized === 'norimemoryedit') {
-    const content = firstString(args['content']);
-    if (content !== undefined) {
-      sections.push({ kind: 'pre', label: 'Content', text: truncatePre(content) });
+  for (const field of payloadFields) {
+    const value = args[field.key];
+    if (!isPresent(value)) continue;
+    if (normalized === 'write' && field.key === 'content') continue;
+    if (normalized === 'edit' && (field.key === 'line_ops' || field.key === 'expected_tag')) continue;
+    if (normalized === 'bash' && field.key === 'command') {
+      const command = firstString(value);
+      if (command !== undefined) {
+        sections.push({ kind: 'pre', label: 'Command', text: `$ ${truncatePre(command)}` });
+      }
+      continue;
     }
+    sections.push({ kind: 'pre', label: field.label, text: formatArgValue(value) });
   }
 
-  if (normalized === 'bash') {
-    const command = firstString(args['command']);
-    if (command !== undefined) {
-      sections.push({ kind: 'pre', label: 'Command', text: `$ ${command}` });
-    }
+  for (const [key, value] of Object.entries(args)) {
+    if (payloadFields.some(field => field.key === key)) continue;
+    if (!shouldLiftValue(value) || !isPresent(value)) continue;
+    sections.push({ kind: 'pre', label: titleCaseKey(key), text: formatArgValue(value) });
   }
 
   if (normalized === 'edit' && parseEditLineOperations(args['line_ops']).length > 0) {
@@ -190,7 +277,7 @@ export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDe
       } else if (changeDiff === undefined || !trimmed.startsWith(changeDiff.slice(0, 32))) {
         sections.push({
           kind: 'pre',
-          label: normalized === 'bash' ? 'Output' : 'Result',
+          label: resultLabel(normalized),
           text: truncatePre(tool.result),
         });
       }
@@ -201,6 +288,8 @@ export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDe
     const fallback = serializeUnknown(tool.args);
     if (fallback !== undefined) {
       sections.push({ kind: 'pre', label: 'Input', text: fallback });
+    } else if (tool.result !== undefined) {
+      sections.push({ kind: 'pre', label: 'Input', text: '(empty)' });
     }
   }
 

--- a/apps/nori-web/src/utils/tool-call-detail.ts
+++ b/apps/nori-web/src/utils/tool-call-detail.ts
@@ -1,5 +1,5 @@
 import type { CodeChange, ToolCall } from '../hooks/useChatMessages';
-import { editLineOperationsDiff, parseEditLineOperations } from './edit-line-ops';
+import { editLineOperationsDiff, isChangedDiffLine, isPlaceholderDiffLine, parseEditLineOperations } from './edit-line-ops';
 
 export interface ToolCallDetailOptions {
   readonly recordedDiff?: string | undefined;
@@ -50,30 +50,33 @@ function writeContentDiff(content: unknown): string {
 
 function compactDiffLines(diff: string): string[] {
   const lines = diff.split('\n').filter(line =>
-    line.startsWith('@@')
-    || ((line.startsWith('+') && !line.startsWith('+++'))
-    || (line.startsWith('-') && !line.startsWith('---'))),
+    line.startsWith('@@') || isChangedDiffLine(line),
   );
   if (lines.length <= MAX_DIFF_LINES) return lines;
   return [...lines.slice(0, MAX_DIFF_LINES), `... ${String(lines.length - MAX_DIFF_LINES)} more changed lines`];
 }
 
 function hasTextDiff(diff: string): boolean {
-  return diff.split('\n').some(line =>
-    (line.startsWith('+') && !line.startsWith('+++'))
-    || (line.startsWith('-') && !line.startsWith('---')),
-  );
+  return diff.split('\n').some(line => isChangedDiffLine(line));
+}
+
+function usableRecordedDiff(diff: string | undefined): string | undefined {
+  if (diff === undefined || diff.length === 0) return undefined;
+  const cleaned = diff
+    .split('\n')
+    .filter(line => !isPlaceholderDiffLine(line))
+    .join('\n')
+    .trim();
+  return hasTextDiff(cleaned) ? cleaned : undefined;
 }
 
 export function buildToolCallChangeDiff(tool: ToolCall, options?: ToolCallDetailOptions): string | undefined {
   const args = asRecord(tool.args);
   const normalized = normalizeToolName(tool.name);
-  const recordedDiff = options?.recordedDiff?.trim();
+  const recordedDiff = usableRecordedDiff(options?.recordedDiff?.trim());
 
   if (normalized === 'edit') {
-    if (recordedDiff !== undefined && recordedDiff.length > 0 && hasTextDiff(recordedDiff)) {
-      return recordedDiff;
-    }
+    if (recordedDiff !== undefined) return recordedDiff;
     const diff = editLineOperationsDiff(args['line_ops']).join('\n');
     return diff.length > 0 ? diff : undefined;
   }
@@ -135,12 +138,25 @@ export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDe
 
   const excludeArgKeys = new Set<string>();
   if (normalized === 'write') excludeArgKeys.add('content');
-  if (normalized === 'edit') excludeArgKeys.add('line_ops');
+  if (normalized === 'edit') {
+    excludeArgKeys.add('line_ops');
+    excludeArgKeys.add('expected_tag');
+  }
   if (normalized === 'bash') excludeArgKeys.add('command');
+  if (normalized === 'norimemorywrite' || normalized === 'norimemoryedit') {
+    excludeArgKeys.add('content');
+  }
 
   const argsSummary = formatArgsSummary(tool, excludeArgKeys);
   if (argsSummary !== undefined) {
     sections.push({ kind: 'pre', label: 'Input', text: argsSummary });
+  }
+
+  if (normalized === 'norimemorywrite' || normalized === 'norimemoryedit') {
+    const content = firstString(args['content']);
+    if (content !== undefined) {
+      sections.push({ kind: 'pre', label: 'Content', text: truncatePre(content) });
+    }
   }
 
   if (normalized === 'bash') {
@@ -181,5 +197,25 @@ export function buildToolCallDetailSections(tool: ToolCall, options?: ToolCallDe
     }
   }
 
+  if (sections.length === 0) {
+    const fallback = serializeUnknown(tool.args);
+    if (fallback !== undefined) {
+      sections.push({ kind: 'pre', label: 'Input', text: fallback });
+    }
+  }
+
   return sections;
+}
+
+function serializeUnknown(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value.length > 0 ? truncatePre(value) : undefined;
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized === undefined || serialized === '{}' || serialized === '[]'
+      ? undefined
+      : truncatePre(serialized);
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/nori-web/src/utils/tool-call-detail.ts
+++ b/apps/nori-web/src/utils/tool-call-detail.ts
@@ -1,5 +1,12 @@
 import type { ToolCall } from '../hooks/useChatMessages';
-import { editLineOperationsDiff, isChangedDiffLine, isPlaceholderDiffLine, parseEditLineOperations } from './edit-line-ops';
+import {
+  diffLineStats,
+  editLineOperationStats,
+  editLineOperationsDiff,
+  isChangedDiffLine,
+  isPlaceholderDiffLine,
+  parseEditLineOperations,
+} from './edit-line-ops';
 
 export interface ToolCallDetailOptions {
   readonly recordedDiff?: string | undefined;
@@ -122,6 +129,23 @@ function usableRecordedDiff(diff: string | undefined): string | undefined {
     .join('\n')
     .trim();
   return hasTextDiff(cleaned) ? cleaned : undefined;
+}
+
+export function toolCallChangeStats(
+  tool: ToolCall,
+  recordedDiff?: string,
+): { additions: number; deletions: number } | undefined {
+  const normalized = normalizeToolName(tool.name);
+  if (normalized !== 'edit' && normalized !== 'write') return undefined;
+
+  const recorded = diffLineStats(recordedDiff);
+  if (recorded !== undefined) return recorded;
+
+  const args = asRecord(tool.args);
+  if (normalized === 'write') return diffLineStats(writeContentDiff(args['content']));
+
+  const operationCounts = editLineOperationStats(args['line_ops']);
+  return operationCounts.additions > 0 || operationCounts.deletions > 0 ? operationCounts : undefined;
 }
 
 export function buildToolCallChangeDiff(tool: ToolCall, options?: ToolCallDetailOptions): string | undefined {

--- a/apps/nori-web/test/ChatView.test.ts
+++ b/apps/nori-web/test/ChatView.test.ts
@@ -1408,6 +1408,66 @@ describe('conversation presentation', () => {
     expect(editDetails.open).toBe(true);
     expect(editDetails.textContent).toContain('+background:#050510;');
     expect(editDetails.textContent).not.toContain('[original line');
+    expect(editDetails.querySelector('.compact-tool-diff-stats b')?.textContent).toBe('+1');
+    expect(editDetails.querySelector('.compact-tool-diff-stats i')?.textContent).toBe('-1');
+  });
+
+  it('shows Edit +added -removed from the recorded diff instead of inflated line_ops ranges', async () => {
+    const blocks = [{
+      id: 'tool-edit-1',
+      type: 'tool' as const,
+      tool: {
+        id: 'tool-edit-1',
+        name: 'Edit',
+        args: {
+          path: 'apps/nori-web/src/components/ChatView.tsx',
+          line_ops: [{ op: 'swap', start: 42, end: 46, content: 'a\nb\nc\nd\ne' }],
+        },
+        result: '[ChatView.tsx#ABCD]\nApplied 1 line operation to ChatView.tsx.',
+      },
+    }];
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: 'Done.', workBlocks: blocks }],
+      codeChanges: [{
+        operationId: 'tool-edit-1',
+        agentId: 'main',
+        operation: 'edit',
+        path: 'apps/nori-web/src/components/ChatView.tsx',
+        diff: '-old a\n-old b\n+new a\n+new b\n+new c',
+        occurredAt: '2026-08-17T00:00:00.000Z',
+      }],
+      isStreaming: false,
+    });
+
+    const stats = container.querySelector('.compact-tool-diff-stats');
+    expect(stats?.getAttribute('aria-label')).toBe('+3 -2');
+    expect(stats?.querySelector('b')?.textContent).toBe('+3');
+    expect(stats?.querySelector('i')?.textContent).toBe('-2');
+    expect(container.querySelector('.compact-tool-copy')?.textContent).toContain('ChatView.tsx');
+  });
+
+  it('falls back to line_ops counts when Edit has no recorded diff', async () => {
+    const blocks = [{
+      id: 'tool-edit-1',
+      type: 'tool' as const,
+      tool: {
+        id: 'tool-edit-1',
+        name: 'Edit',
+        args: {
+          path: 'src/utils/format.ts',
+          line_ops: [{ op: 'swap', start: 4, end: 4, content: 'one\ntwo' }],
+        },
+        result: '[src/utils/format.ts#88BB]\nApplied 1 line operation to src/utils/format.ts.',
+      },
+    }];
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: 'Done.', workBlocks: blocks }],
+      isStreaming: false,
+    });
+
+    const stats = container.querySelector('.compact-tool-diff-stats');
+    expect(stats?.querySelector('b')?.textContent).toBe('+2');
+    expect(stats?.querySelector('i')?.textContent).toBe('-1');
   });
 
   it('lets any tool call expand even when there is no extra payload yet', async () => {

--- a/apps/nori-web/test/ChatView.test.ts
+++ b/apps/nori-web/test/ChatView.test.ts
@@ -1233,6 +1233,7 @@ describe('conversation presentation', () => {
     });
     expect(editDetails.open).toBe(true);
     expect(editDetails.textContent).toContain('+updated');
+    expect(editDetails.textContent).not.toContain('[original line');
 
     const bashDetails = toolCalls[1]!;
     expect(bashDetails.textContent).toContain('Failed');
@@ -1242,6 +1243,64 @@ describe('conversation presentation', () => {
     });
     expect(bashDetails.textContent).toContain('npm test');
     expect(bashDetails.textContent).toContain('Command failed with exit code: 1.');
+  });
+
+  it('expands Edit details without original-line placeholders from recorded diffs', async () => {
+    const blocks = [{
+      id: 'tool-edit-1',
+      type: 'tool' as const,
+      tool: {
+        id: 'tool-edit-1',
+        name: 'Edit',
+        args: {
+          path: 'src/a.ts',
+          line_ops: [{ op: 'swap', start: 1, end: 1, content: 'background:#050510;' }],
+        },
+        result: 'Updated src/a.ts',
+      },
+    }];
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: 'Done.', workBlocks: blocks }],
+      codeChanges: [{
+        operationId: 'tool-edit-1',
+        agentId: 'main',
+        operation: 'edit',
+        path: 'src/a.ts',
+        diff: '- [original line 1 replaced]\n+background:#050510;',
+        occurredAt: '2026-08-17T00:00:00.000Z',
+      }],
+      isStreaming: false,
+    });
+
+    const editDetails = container.querySelector<HTMLDetailsElement>('.expandable-tool-call.tool-edit')!;
+    await act(async () => {
+      editDetails.querySelector('summary')?.click();
+      await Promise.resolve();
+    });
+    expect(editDetails.open).toBe(true);
+    expect(editDetails.textContent).toContain('+background:#050510;');
+    expect(editDetails.textContent).not.toContain('[original line');
+  });
+
+  it('lets any tool call expand even when there is no extra payload yet', async () => {
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: '' }],
+      workBlocks: [{
+        id: 'tool-1',
+        type: 'tool',
+        tool: { id: 'tool-1', name: 'TodoList', args: {} },
+      }],
+      isStreaming: true,
+    });
+
+    const toolCall = container.querySelector<HTMLDetailsElement>('.expandable-tool-call')!;
+    expect(toolCall.querySelector('.tool-call-chevron')).not.toBeNull();
+    await act(async () => {
+      toolCall.querySelector('summary')?.click();
+      await Promise.resolve();
+    });
+    expect(toolCall.open).toBe(true);
+    expect(toolCall.textContent).toContain('Waiting for this tool to finish');
   });
 
   it('renders ordinary live text as normal assistant output while work is active', async () => {

--- a/apps/nori-web/test/ChatView.test.ts
+++ b/apps/nori-web/test/ChatView.test.ts
@@ -162,6 +162,7 @@ describe('chat image attachments', () => {
         source: expect.objectContaining({ kind: 'base64', media_type: 'image/png' }),
       })],
       'queue',
+      expect.objectContaining({ model: 'multimodal-model' }),
     );
   });
 
@@ -400,6 +401,17 @@ describe('model thinking options', () => {
     });
 
     expect(container.querySelector('.composer-model-popover')?.getAttribute('aria-hidden')).toBe('false');
+  });
+
+  it('falls back to the draft model when the session model is an empty string', async () => {
+    const { container } = await renderChat({
+      session: session(''),
+      draftAgentConfig: { model: 'multimodal-model' },
+      models: [model('multimodal-model', ['tool_use', 'image_in'])],
+    });
+    const trigger = container.querySelector<HTMLButtonElement>('.composer-model-trigger');
+    expect(trigger?.classList.contains('invalid')).toBe(false);
+    expect(trigger?.textContent).toContain('multimodal-model');
   });
 
   it('offers Fast and Think when a third-party model omits reasoning metadata', () => {
@@ -894,7 +906,12 @@ describe('live response controls', () => {
 
     await act(async () => container.querySelector<HTMLButtonElement>('.chat-send-btn')!.click());
 
-    expect(onSendMessage).toHaveBeenCalledWith('Focus on the parser race', [], 'steer');
+    expect(onSendMessage).toHaveBeenCalledWith(
+      'Focus on the parser race',
+      [],
+      'steer',
+      expect.objectContaining({ model: 'multimodal-model' }),
+    );
     expect(container.querySelector<HTMLButtonElement>('.chat-send-btn')!.disabled).toBe(true);
     expect(input.value).toBe('Focus on the parser race');
 
@@ -939,7 +956,7 @@ describe('chat slash commands and task-mode shortcut', () => {
       'Implement the parser fix',
       [],
       'queue',
-      { loopMode: true },
+      expect.objectContaining({ loopMode: true, model: 'multimodal-model' }),
     );
     expect(localStorage.getItem('nori-composer-loop-mode')).toBe('true');
   });

--- a/apps/nori-web/test/ChatView.test.ts
+++ b/apps/nori-web/test/ChatView.test.ts
@@ -1245,6 +1245,134 @@ describe('conversation presentation', () => {
     expect(bashDetails.textContent).toContain('Command failed with exit code: 1.');
   });
 
+  it('expands Read, Grep, Agent, MCP, Write, Glob, FetchURL, Browser, and TodoList tool details with full payloads', async () => {
+    const prompt = `Inspect the ${'login '.repeat(40)}flow and list every auth entry point.`;
+    const writeBody = '# Auth\n\nLogin issues a token for the given user.\n';
+    const blocks = [
+      {
+        id: 'tool-read-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-read-1',
+          name: 'Read',
+          args: { path: 'src/auth.ts' },
+          result: 'export function login() {\n  return token;\n}\n',
+        },
+      },
+      {
+        id: 'tool-grep-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-grep-1',
+          name: 'Grep',
+          args: { pattern: 'countActiveAgents', path: 'apps/nori-web' },
+          result: 'apps/nori-web/src/App.tsx:593:export function countActiveAgents(',
+        },
+      },
+      {
+        id: 'tool-agent-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-agent-1',
+          name: 'Agent',
+          args: { subagent_type: 'explore', prompt },
+          result: 'Auth lives in src/auth.ts.',
+        },
+      },
+      {
+        id: 'tool-mcp-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-mcp-1',
+          name: 'mcp__github__create_issue',
+          args: { title: 'Fix badge', body: 'Wrong session.\nCount paused agents.' },
+          result: 'Created issue #12',
+        },
+      },
+      {
+        id: 'tool-write-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-write-1',
+          name: 'Write',
+          args: { path: 'notes/auth.md', content: writeBody },
+          result: 'Wrote notes/auth.md',
+        },
+      },
+      {
+        id: 'tool-glob-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-glob-1',
+          name: 'Glob',
+          args: { pattern: '**/*.test.ts', path: 'apps/nori-web' },
+          result: 'apps/nori-web/test/ChatView.test.ts',
+        },
+      },
+      {
+        id: 'tool-fetch-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-fetch-1',
+          name: 'FetchURL',
+          args: { url: 'https://example.com/docs/api' },
+          result: '# API Reference\n\nGET /v1/sessions returns the session list.',
+        },
+      },
+      {
+        id: 'tool-browser-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-browser-1',
+          name: 'Browser',
+          args: { action: 'navigate', url: 'https://example.com/docs/api' },
+          result: 'Navigated to https://example.com/docs/api\nTitle: API Reference',
+        },
+      },
+      {
+        id: 'tool-todo-1',
+        type: 'tool' as const,
+        tool: {
+          id: 'tool-todo-1',
+          name: 'TodoList',
+          args: { todos: [{ title: 'Show tool details', status: 'in_progress' }] },
+          result: 'Current todo list:\n  [in_progress] Show tool details',
+        },
+      },
+    ];
+    const { container } = await renderChat({
+      messages: [{ id: 'assistant-1', role: 'assistant', text: 'Done.', workBlocks: blocks }],
+      isStreaming: false,
+    });
+
+    const toolCalls = container.querySelectorAll<HTMLDetailsElement>('.expandable-tool-call');
+    expect(toolCalls).toHaveLength(9);
+
+    const expectations = [
+      ['src/auth.ts', 'export function login()'],
+      ['countActiveAgents', 'App.tsx'],
+      [prompt, 'src/auth.ts'],
+      ['Fix badge', 'Count paused agents.', 'Created issue #12'],
+      ['notes/auth.md', 'Login issues a token', 'Wrote notes/auth.md'],
+      ['**/*.test.ts', 'ChatView.test.ts'],
+      ['https://example.com/docs/api', 'GET /v1/sessions'],
+      ['navigate', 'API Reference'],
+      ['Show tool details', '[in_progress]'],
+    ] as const;
+
+    for (const [index, snippets] of expectations.entries()) {
+      const details = toolCalls[index]!;
+      await act(async () => {
+        details.querySelector('summary')?.click();
+        await Promise.resolve();
+      });
+      expect(details.open).toBe(true);
+      for (const snippet of snippets) {
+        expect(details.textContent).toContain(snippet);
+      }
+    }
+  });
+
   it('expands Edit details without original-line placeholders from recorded diffs', async () => {
     const blocks = [{
       id: 'tool-edit-1',

--- a/apps/nori-web/test/PrimaryNavigation.test.ts
+++ b/apps/nori-web/test/PrimaryNavigation.test.ts
@@ -139,6 +139,28 @@ describe('PrimaryNavigation', () => {
 
     expect(countActiveAgents(['agent-stopped'], [stopped], [])).toBe(0);
   });
+
+  it('counts swarm agents from status snapshots without live ids', () => {
+    const run: SwarmStatus = {
+      swarm_id: 'swarm-other',
+      status: 'running',
+      task_count: 1,
+      completed_count: 0,
+      tasks: [{
+        id: 'agent-other',
+        agent_id: 'agent-other',
+        profile: 'coder',
+        label: 'Implement',
+        status: 'running',
+      }],
+    };
+    expect(countActiveAgents([], [run], [])).toBe(1);
+    expect(countActiveAgents([], [{
+      ...run,
+      status: 'paused',
+      tasks: [{ ...run.tasks![0]!, status: 'paused' }],
+    }], [])).toBe(1);
+  });
 });
 
 describe('WindowControls', () => {

--- a/apps/nori-web/test/ProviderSettings.test.ts
+++ b/apps/nori-web/test/ProviderSettings.test.ts
@@ -186,6 +186,51 @@ describe('ProviderSettings', () => {
     const secondPatch = updateConfig.mock.calls[0]?.[0] as { providers?: Record<string, Record<string, unknown>> };
     expect(secondPatch.providers?.openrouter?.api_key).toBe('sk-replacement');
   });
+
+  it('does not wipe discovered aliases or write leftover custom IDs when auto-discovery is on', async () => {
+    vi.mocked(api.providers.list).mockResolvedValue({
+      items: [{ ...PROVIDER, custom_models: ['leftover-id'] }],
+    });
+    vi.mocked(api.getConfig).mockResolvedValue({
+      models: {
+        'openrouter/existing': { provider: 'openrouter', model: 'existing' },
+      },
+      default_model: 'openrouter/existing',
+    });
+    const updateConfig = vi.mocked(api.updateConfig);
+    const { container } = await renderProviders();
+    await openEditor(container);
+    await act(async () => {
+      saveButton(container).click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(updateConfig).toHaveBeenCalled();
+    });
+    const firstPatch = updateConfig.mock.calls[0]?.[0] as { models?: Record<string, unknown> };
+    expect(firstPatch.models).toBeUndefined();
+  });
+
+  it('sets default_model after a successful refresh when none is configured', async () => {
+    const updateConfig = vi.mocked(api.updateConfig);
+    vi.mocked(api.getConfig)
+      .mockResolvedValueOnce({ models: {} })
+      .mockResolvedValueOnce({
+        models: { 'openrouter/gpt-4o': { provider: 'openrouter', model: 'gpt-4o' } },
+      });
+    const { container } = await renderProviders();
+    await openEditor(container);
+    await act(async () => {
+      saveButton(container).click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(updateConfig.mock.calls.some(call => {
+        const patch = call[0] as { default_model?: string };
+        return patch.default_model === 'openrouter/gpt-4o';
+      })).toBe(true);
+    });
+  });
 });
 
 async function renderProviders() {

--- a/apps/nori-web/test/SwarmPanel.test.ts
+++ b/apps/nori-web/test/SwarmPanel.test.ts
@@ -351,6 +351,24 @@ describe('SwarmPanel projections', () => {
     expect([...activity.ids].sort()).toEqual(['running-1', 'running-2']);
     expect(activity.untracked).toBe(0);
 
+    const paused = runningSwarmAgents([{
+      ...run('swarm-paused', 1),
+      status: 'paused',
+      tasks: [
+        { id: 'paused-1', label: 'Paused', status: 'paused' },
+        { id: 'queued-1', label: 'Queued', status: 'pending' },
+      ],
+    }]);
+    expect([...paused.ids]).toEqual(['paused-1']);
+    expect(paused.untracked).toBe(0);
+
+    const untrackedPaused = runningSwarmAgents([{
+      ...run('swarm-untracked', 1),
+      status: 'paused',
+    }]);
+    expect(untrackedPaused.ids.size).toBe(0);
+    expect(untrackedPaused.untracked).toBe(1);
+
     const stopped = runningSwarmAgents([{
       ...run('swarm-stopped', 1),
       status: 'stopped',

--- a/apps/nori-web/test/VaultGraph.test.ts
+++ b/apps/nori-web/test/VaultGraph.test.ts
@@ -2,7 +2,7 @@ import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Note } from '../src/api/client';
-import { collectRelatedNotes, resolveVaultNote } from '../src/components/VaultBrowser';
+import { collectRelatedNotes, formatVaultTimestamp, resolveVaultNote } from '../src/components/VaultBrowser';
 import { forceSameType, VaultGraph } from '../src/components/VaultGraph';
 import { I18nProvider } from '../src/i18n';
 
@@ -78,6 +78,14 @@ describe('vault related-note projection', () => {
       { note: decision, direction: 'outgoing' },
       { note: review, direction: 'backlink' },
     ]);
+  });
+});
+
+describe('vault timestamps', () => {
+  it('formats ISO write times and leaves invalid values unchanged', () => {
+    expect(formatVaultTimestamp('not-a-date', 'en')).toBe('not-a-date');
+    expect(formatVaultTimestamp('2026-08-17T01:02:03.000Z', 'en')).not.toBe('2026-08-17T01:02:03.000Z');
+    expect(formatVaultTimestamp('2026-08-17T01:02:03.000Z', 'en')).toMatch(/2026/);
   });
 });
 

--- a/apps/nori-web/test/WorkspaceInspector.test.ts
+++ b/apps/nori-web/test/WorkspaceInspector.test.ts
@@ -563,7 +563,7 @@ describe('workspace change presentation', () => {
       agentId: 'main',
       operation: 'edit',
       path: 'stardrift.html',
-      diff: '- [original line 1 replaced]\n+background:#050510;',
+      diff: '@@ replace lines 1-1 @@\n+background:#050510;',
       occurredAt: '2026-07-15T10:43:43.244Z',
     }]);
   });

--- a/apps/nori-web/test/apiClient.test.ts
+++ b/apps/nori-web/test/apiClient.test.ts
@@ -40,6 +40,32 @@ describe('prompt execution options', () => {
     });
   });
 
+  it('includes the selected model on prompt submit', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      code: 0,
+      msg: 'ok',
+      data: {
+        prompt_id: 'prompt-1',
+        user_message_id: 'msg-1',
+        status: 'running',
+        content: [{ type: 'text', text: 'ship the release' }],
+        created_at: '2026-07-15T00:00:00.000Z',
+      },
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = createClient('http://localhost:3000');
+
+    await client.sendPrompt('session-1', 'ship the release', [], {
+      model: 'openrouter/gpt-4o',
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: 'openrouter/gpt-4o',
+      content: [{ type: 'text', text: 'ship the release' }],
+    });
+  });
+
   it('uses the collection steer endpoint for queued guidance', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       code: 0,

--- a/apps/nori-web/test/tool-call-detail.test.ts
+++ b/apps/nori-web/test/tool-call-detail.test.ts
@@ -4,6 +4,7 @@ import {
   buildToolCallChangeDiff,
   buildToolCallDetailSections,
   isToolCallFailed,
+  toolCallChangeStats,
 } from '../src/utils/tool-call-detail';
 
 describe('tool-call-detail', () => {
@@ -221,5 +222,39 @@ describe('tool-call-detail', () => {
     });
     expect(sections.filter(section => section.label === 'Result')).toHaveLength(0);
     expect(sections.some(section => section.kind === 'diff')).toBe(true);
+  });
+
+  it('counts Edit +added -removed from the recorded diff rather than line_ops ranges', () => {
+    const tool = {
+      name: 'Edit',
+      args: {
+        path: 'src/a.ts',
+        line_ops: [{ op: 'swap', start: 42, end: 46, content: 'a\nb\nc\nd\ne' }],
+      },
+      result: '[src/a.ts#ABCD]\nApplied 1 line operation to src/a.ts.',
+    };
+    expect(toolCallChangeStats(tool)).toEqual({ additions: 5, deletions: 5 });
+    expect(toolCallChangeStats(tool, '-old a\n-old b\n+new a\n+new b\n+new c')).toEqual({
+      additions: 3,
+      deletions: 2,
+    });
+  });
+
+  it('counts placeholder replacement diffs as +1 -1', () => {
+    expect(toolCallChangeStats({
+      name: 'Edit',
+      args: { path: 'src/a.ts', line_ops: [{ op: 'swap', start: 1, end: 1, content: 'next' }] },
+    }, '- [original line 1 replaced]\n+next')).toEqual({ additions: 1, deletions: 1 });
+  });
+
+  it('counts insert and delete Edit operations', () => {
+    expect(toolCallChangeStats({
+      name: 'Edit',
+      args: { line_ops: [{ op: 'insert_post', line: 8, content: 'one\ntwo\nthree' }] },
+    })).toEqual({ additions: 3, deletions: 0 });
+    expect(toolCallChangeStats({
+      name: 'Edit',
+      args: { line_ops: [{ op: 'del', start: 10, end: 12 }] },
+    })).toEqual({ additions: 0, deletions: 3 });
   });
 });

--- a/apps/nori-web/test/tool-call-detail.test.ts
+++ b/apps/nori-web/test/tool-call-detail.test.ts
@@ -39,6 +39,48 @@ describe('tool-call-detail', () => {
     expect(diff).toBe('-old line\n+new line');
   });
 
+  it('strips original-line placeholders from recorded Edit diffs', () => {
+    const diff = buildToolCallChangeDiff({
+      id: 'edit-1',
+      name: 'Edit',
+      args: {
+        path: 'src/a.ts',
+        line_ops: [{ op: 'swap', start: 1, end: 1, content: 'background:#050510;' }],
+      },
+    }, {
+      recordedDiff: '- [original line 1 replaced]\n+background:#050510;',
+    });
+    expect(diff).toBe('+background:#050510;');
+    expect(diff).not.toContain('[original line');
+  });
+
+  it('falls back to line_ops when recorded Edit diffs are only placeholders', () => {
+    const diff = buildToolCallChangeDiff({
+      name: 'Edit',
+      args: {
+        path: 'src/a.ts',
+        line_ops: [{ op: 'swap', start: 1, end: 1, content: 'updated' }],
+      },
+    }, {
+      recordedDiff: '- [original line 1 replaced]\n- [original line 2 deleted]',
+    });
+    expect(diff).toContain('@@ replace lines 1-1 @@');
+    expect(diff).toContain('+updated');
+    expect(diff).not.toContain('[original line');
+  });
+
+  it('shows memory edit content without truncating it in Input', () => {
+    const body = 'A'.repeat(300);
+    const sections = buildToolCallDetailSections({
+      name: 'nori_memory_edit',
+      args: { title: 'Architecture choice', content: body },
+      result: 'Note edited: analysis/architecture.md',
+    });
+    expect(sections.some(section => section.label === 'Input' && section.text?.includes('Architecture choice'))).toBe(true);
+    expect(sections.some(section => section.label === 'Content' && section.text === body)).toBe(true);
+    expect(sections.some(section => section.label === 'Input' && section.text?.includes(body))).toBe(false);
+  });
+
   it('builds write diff from content', () => {
     const diff = buildToolCallChangeDiff({
       name: 'Write',

--- a/apps/nori-web/test/tool-call-detail.test.ts
+++ b/apps/nori-web/test/tool-call-detail.test.ts
@@ -81,6 +81,120 @@ describe('tool-call-detail', () => {
     expect(sections.some(section => section.label === 'Input' && section.text?.includes(body))).toBe(false);
   });
 
+  it('shows full input and output for Read, Grep, Agent, and unknown tools', () => {
+    const prompt = `Please inspect ${'auth'.repeat(80)} and summarize the login flow.`;
+    const readSections = buildToolCallDetailSections({
+      name: 'Read',
+      args: { path: 'src/app.ts', line_offset: 10 },
+      result: 'export function main() {\n  return 1;\n}\n',
+    });
+    expect(readSections.some(section => section.label === 'Path' && section.text?.includes('src/app.ts'))).toBe(true);
+    expect(readSections.some(section => section.label === 'Input' && section.text?.includes('line_offset'))).toBe(true);
+    expect(readSections.some(section => section.label === 'File' && section.text?.includes('export function main()'))).toBe(true);
+
+    const grepSections = buildToolCallDetailSections({
+      name: 'Grep',
+      args: { pattern: 'countActiveAgents', path: 'apps/nori-web', glob: '*.ts' },
+      result: 'apps/nori-web/src/App.tsx:593:export function countActiveAgents(',
+    });
+    expect(grepSections.some(section => section.label === 'Pattern' && section.text === 'countActiveAgents')).toBe(true);
+    expect(grepSections.some(section => section.label === 'Matches' && section.text?.includes('App.tsx'))).toBe(true);
+
+    const agentSections = buildToolCallDetailSections({
+      name: 'Agent',
+      args: { subagent_type: 'explore', prompt },
+      result: 'The login flow lives in src/auth.ts.',
+    });
+    expect(agentSections.some(section => section.label === 'Prompt' && section.text === prompt)).toBe(true);
+    expect(agentSections.some(section => section.label === 'Input' && section.text?.includes(prompt))).toBe(false);
+    expect(agentSections.some(section => section.label === 'Result' && section.text?.includes('src/auth.ts'))).toBe(true);
+
+    const mcpSections = buildToolCallDetailSections({
+      name: 'mcp__github__create_issue',
+      args: {
+        title: 'Fix badge',
+        body: 'The collaboration badge counted the wrong session.\nCount paused agents too.',
+      },
+      result: 'Created issue #12',
+    });
+    expect(mcpSections.some(section => section.label === 'Input' && section.text?.includes('Fix badge'))).toBe(true);
+    expect(mcpSections.some(section => section.label === 'Body' && section.text?.includes('wrong session'))).toBe(true);
+    expect(mcpSections.some(section => section.label === 'Result' && section.text?.includes('#12'))).toBe(true);
+  });
+
+  it('shows full payloads for Write, Glob, FetchURL, Browser, WebSearch, and TodoList', () => {
+    const writeBody = '# Auth\n\nLogin issues a token for the given user.\n';
+    const writeSections = buildToolCallDetailSections({
+      name: 'Write',
+      args: { path: 'notes/auth.md', content: writeBody },
+      result: 'Wrote notes/auth.md',
+    });
+    expect(writeSections.some(section => section.label === 'Input' && section.text?.includes('notes/auth.md'))).toBe(true);
+    expect(writeSections.some(section => section.kind === 'diff' && section.lines?.some(line => line.includes('Login issues a token')))).toBe(true);
+    expect(writeSections.some(section => section.label === 'Result' && section.text?.includes('Wrote notes/auth.md'))).toBe(true);
+
+    const globSections = buildToolCallDetailSections({
+      name: 'Glob',
+      args: { pattern: '**/*.test.ts', path: 'apps/nori-web' },
+      result: 'apps/nori-web/test/ChatView.test.ts\napps/nori-web/test/tool-call-detail.test.ts',
+    });
+    expect(globSections.some(section => section.label === 'Pattern' && section.text === '**/*.test.ts')).toBe(true);
+    expect(globSections.some(section => section.label === 'Input' && section.text?.includes('apps/nori-web'))).toBe(true);
+    expect(globSections.some(section => section.label === 'Files' && section.text?.includes('ChatView.test.ts'))).toBe(true);
+
+    const fetchSections = buildToolCallDetailSections({
+      name: 'FetchURL',
+      args: { url: 'https://example.com/docs/api' },
+      result: '# API Reference\n\nGET /v1/sessions returns the session list.',
+    });
+    expect(fetchSections.some(section => section.label === 'URL' && section.text === 'https://example.com/docs/api')).toBe(true);
+    expect(fetchSections.some(section => section.label === 'Page' && section.text?.includes('GET /v1/sessions'))).toBe(true);
+
+    const browserSections = buildToolCallDetailSections({
+      name: 'Browser',
+      args: { action: 'type', url: 'https://example.com/login', text: 'user@example.com', ref: 'e12' },
+      result: 'Typed into email field\nSnapshot: 8 interactive elements.',
+    });
+    expect(browserSections.some(section => section.label === 'Input' && section.text?.includes('type'))).toBe(true);
+    expect(browserSections.some(section => section.label === 'Text' && section.text === 'user@example.com')).toBe(true);
+    expect(browserSections.some(section => section.label === 'Snapshot' && section.text?.includes('8 interactive elements'))).toBe(true);
+
+    const query = `RFC 9110 HTTP semantics ${'cache '.repeat(40)}invalidation`;
+    const searchSections = buildToolCallDetailSections({
+      name: 'WebSearch',
+      args: { query },
+      result: '1. RFC 9110 — HTTP Semantics\n2. Cache invalidation is the origin\'s job.',
+    });
+    expect(searchSections.some(section => section.label === 'Query' && section.text === query)).toBe(true);
+    expect(searchSections.some(section => section.label === 'Results' && section.text?.includes('RFC 9110'))).toBe(true);
+
+    const todoSections = buildToolCallDetailSections({
+      name: 'TodoList',
+      args: {
+        todos: [
+          { title: 'Fix collaboration badge', status: 'done' },
+          { title: 'Show tool details', status: 'in_progress' },
+        ],
+      },
+      result: 'Current todo list:\n  [done] Fix collaboration badge\n  [in_progress] Show tool details',
+    });
+    expect(todoSections.some(section => section.label === 'Todos' && section.text?.includes('Fix collaboration badge'))).toBe(true);
+    expect(todoSections.some(section => section.label === 'Result' && section.text?.includes('[in_progress] Show tool details'))).toBe(true);
+  });
+
+  it('does not truncate long input or output at 240 characters', () => {
+    const title = `Issue ${'title '.repeat(80)}end`;
+    const output = `Match ${'line '.repeat(80)}end`;
+    const sections = buildToolCallDetailSections({
+      name: 'mcp__linear__create_issue',
+      args: { title, team: 'ENG' },
+      result: output,
+    });
+    expect(sections.some(section => section.label === 'Title' && section.text === title)).toBe(true);
+    expect(sections.some(section => section.label === 'Result' && section.text === output)).toBe(true);
+    expect(JSON.stringify(sections)).not.toContain('…');
+  });
+
   it('builds write diff from content', () => {
     const diff = buildToolCallChangeDiff({
       name: 'Write',

--- a/docs/en/reference/tools.md
+++ b/docs/en/reference/tools.md
@@ -107,15 +107,21 @@ Nori-specific tools extend the built-in tool set with shared memory, documentati
 | --- | --- | --- |
 | `nori_memory_search` | Follows permission rules | Search the Obsidian shared memory vault |
 | `nori_memory_write` | Follows permission rules | Write analysis, decision, task, or review notes to the vault |
+| `nori_memory_edit` | Follows permission rules | Update an existing vault note in place by exact title |
+| `nori_memory_remove` | Follows permission rules | Delete a vault note by exact title |
 | `nori_plan_write` | Follows permission rules; not blocked by read-only mode | Write plan, design, or analysis documents in approved workspace directories |
 | `nori_swarm_launch` | Follows permission rules | Launch a configured DAG swarm template |
 | `nori_swarm_status` | Follows permission rules | Check a configured swarm's status |
 | `nori_swarm_result` | Follows permission rules | Retrieve a configured swarm's result |
 | `nori_ask_parent` | Subagent only | Let a subagent ask its parent Agent for guidance |
 
-**`nori_memory_search`** accepts concrete `keywords`, optional `note_types`, `top_k`, `include_linked`, `link_depth`, `chain_depth`, and `follow_up_keywords`. Use chained retrieval (`chain_depth: 1` or `2`) when the first results reveal better terms or linked notes.
+**`nori_memory_search`** accepts concrete `keywords`, optional `note_types`, `top_k`, `include_linked`, `link_depth`, `chain_depth`, and `follow_up_keywords`. Use chained retrieval (`chain_depth: 1` or `2`) when the first results reveal better terms or linked notes. Matching notes include a write timestamp when the vault stores one.
 
 **`nori_memory_write`** records structured notes in the shared vault. Use it for durable task progress, architecture analysis, review findings, and decisions that future turns or subagents should retrieve.
+
+**`nori_memory_edit`** updates an existing note in place by exact title and does not create a new file. Omit `links` to keep the current wiki-links; pass `["None"]` or `[]` to clear them. Prefer this over `nori_memory_remove` when correcting a note.
+
+**`nori_memory_remove`** deletes a note by exact title. Use it only for notes that are obsolete.
 
 **`nori_plan_write`** writes only documentation-like files under approved directories such as `docs/`, `plans/`, `.nori-code/`, `design/`, or `specs/`, with extensions such as `.md`, `.txt`, `.yaml`, `.json`, and `.toml`. It is meant for plans and design documents, not source-code edits.
 

--- a/docs/zh/reference/tools.md
+++ b/docs/zh/reference/tools.md
@@ -107,15 +107,21 @@ Nori 专用工具在内置工具集上增加共享记忆、文档写入和已配
 | --- | --- | --- |
 | `nori_memory_search` | 按权限规则处理 | 搜索 Obsidian 共享记忆库 |
 | `nori_memory_write` | 按权限规则处理 | 向记忆库写入 analysis、decision、task 或 review 笔记 |
+| `nori_memory_edit` | 按权限规则处理 | 按精确标题原地更新已有笔记 |
+| `nori_memory_remove` | 按权限规则处理 | 按精确标题删除笔记 |
 | `nori_plan_write` | 按权限规则处理；不受只读模式拦截 | 在允许的工作区目录写入计划、设计或分析文档 |
 | `nori_swarm_launch` | 按权限规则处理 | 启动已配置的 DAG swarm 模板 |
 | `nori_swarm_status` | 按权限规则处理 | 查询已配置 swarm 的状态 |
 | `nori_swarm_result` | 按权限规则处理 | 获取已配置 swarm 的结果 |
 | `nori_ask_parent` | 仅子 Agent 可用 | 让子 Agent 向父 Agent 请求指导 |
 
-**`nori_memory_search`** 接受具体的 `keywords`，以及可选的 `note_types`、`top_k`、`include_linked`、`link_depth`、`chain_depth` 和 `follow_up_keywords`。当第一轮结果暴露出更好的关键词或链接笔记时，使用链式检索（`chain_depth: 1` 或 `2`）。
+**`nori_memory_search`** 接受具体的 `keywords`，以及可选的 `note_types`、`top_k`、`include_linked`、`link_depth`、`chain_depth` 和 `follow_up_keywords`。当第一轮结果暴露出更好的关键词或链接笔记时，使用链式检索（`chain_depth: 1` 或 `2`）。匹配笔记会带上写入时间（如果记忆库中有记录）。
 
 **`nori_memory_write`** 把结构化笔记写入共享记忆库。适合记录任务进度、架构分析、审阅发现，以及未来轮次或子 Agent 需要检索的决策。
+
+**`nori_memory_edit`** 按精确标题原地更新已有笔记，不会新建文件。省略 `links` 会保留当前 wiki-links；传入 `["None"]` 或 `[]` 可清空链接。修正笔记时优先使用此工具，而不是 `nori_memory_remove`。
+
+**`nori_memory_remove`** 按精确标题删除笔记。只用于确实过时的笔记。
 
 **`nori_plan_write`** 只写入 `docs/`、`plans/`、`.nori-code/`、`design/`、`specs/` 等允许目录下的文档类文件，扩展名包括 `.md`、`.txt`、`.yaml`、`.json` 和 `.toml`。它用于计划和设计文档，不用于源码编辑。
 

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -67,9 +67,11 @@ export class ToolManager {
     if (this.agent.obsidianMemory) {
       const memSearch = new b.NoriMemorySearchTool(this.agent.obsidianMemory) as any;
       const memWrite = new b.NoriMemoryWriteTool(this.agent.obsidianMemory) as any;
+      const memEdit = new b.NoriMemoryEditTool(this.agent.obsidianMemory) as any;
       const memRemove = new b.NoriMemoryRemoveTool(this.agent.obsidianMemory) as any;
       this.builtinTools.set(memSearch.name, memSearch);
       this.builtinTools.set(memWrite.name, memWrite);
+      this.builtinTools.set(memEdit.name, memEdit);
       this.builtinTools.set(memRemove.name, memRemove);
     }
     if (this.agent.swarmManager) {
@@ -566,6 +568,8 @@ export class ToolManager {
           new b.NoriMemorySearchTool(this.agent.obsidianMemory),
         this.agent.obsidianMemory &&
           new b.NoriMemoryWriteTool(this.agent.obsidianMemory),
+        this.agent.obsidianMemory &&
+          new b.NoriMemoryEditTool(this.agent.obsidianMemory),
         this.agent.obsidianMemory &&
           new b.NoriMemoryRemoveTool(this.agent.obsidianMemory),
         this.agent.swarmManager &&

--- a/packages/agent-core/src/profile/custom.ts
+++ b/packages/agent-core/src/profile/custom.ts
@@ -55,7 +55,7 @@ function filterTools(baseTools: string[], toolPool: string[], permissions: Custo
   if (!permissions) return [...baseTools];
   const groups: Record<keyof NonNullable<CustomAgentConfig['permissions']>, Set<string>> = {
     read: new Set(['Read', 'Grep', 'Glob', 'ReadMediaFile', 'nori_memory_search']),
-    write: new Set(['Write', 'Edit', 'nori_memory_write', 'nori_memory_remove', 'nori_plan_write']),
+    write: new Set(['Write', 'Edit', 'nori_memory_write', 'nori_memory_edit', 'nori_memory_remove', 'nori_plan_write']),
     shell: new Set(['Bash', 'TaskList', 'TaskOutput', 'TaskStop']),
     web: new Set(['WebSearch', 'FetchURL', 'Browser']),
     delegate: new Set(['Agent', 'AgentSwarm', 'AgentSwarmControl', 'nori_swarm_launch', 'nori_swarm_status', 'nori_swarm_result']),

--- a/packages/agent-core/src/profile/default/agent.yaml
+++ b/packages/agent-core/src/profile/default/agent.yaml
@@ -39,6 +39,7 @@ tools:
   - mcp__*
   - nori_memory_search
   - nori_memory_write
+  - nori_memory_edit
   - nori_memory_remove
   - nori_plan_write
   - nori_swarm_launch

--- a/packages/agent-core/src/profile/default/coder.yaml
+++ b/packages/agent-core/src/profile/default/coder.yaml
@@ -25,6 +25,7 @@ tools:
   - Agent
   - nori_memory_search
   - nori_memory_write
+  - nori_memory_edit
   - nori_memory_remove
   - nori_plan_write
   - nori_swarm_launch

--- a/packages/agent-core/src/profile/default/nori-agent.yaml
+++ b/packages/agent-core/src/profile/default/nori-agent.yaml
@@ -41,6 +41,7 @@ tools:
   - mcp__*
   - nori_memory_search
   - nori_memory_write
+  - nori_memory_edit
   - nori_memory_remove
   - nori_plan_write
   - nori_swarm_launch

--- a/packages/agent-core/src/profile/default/nori-coder-system.md
+++ b/packages/agent-core/src/profile/default/nori-coder-system.md
@@ -29,6 +29,7 @@ Use these configured agents by exact name when delegating work:
 {% endif %}
 | nori_memory_search | Check prior decisions and analyses before planning; call again with new keywords when needed |
 | nori_memory_write | Record your plan, decisions, and findings |
+| nori_memory_edit | Update an existing note in place by exact title |
 | nori_memory_remove | Delete obsolete notes by title |
 | nori_plan_write | Write plans/specs. In plan mode it targets the current session plan file used by ExitPlanMode; not source code |
 | AgentSwarm | Delegate one or many implementation/review tasks through the built-in swarm pipeline; supports heterogeneous `tasks` and `depends_on` DAGs |

--- a/packages/agent-core/src/profile/default/nori-coder.yaml
+++ b/packages/agent-core/src/profile/default/nori-coder.yaml
@@ -33,6 +33,7 @@ tools:
   - mcp__*
   - nori_memory_search
   - nori_memory_write
+  - nori_memory_edit
   - nori_memory_remove
   - nori_plan_write
   - AgentSwarm

--- a/packages/agent-core/src/profile/default/nori-system.md
+++ b/packages/agent-core/src/profile/default/nori-system.md
@@ -12,6 +12,7 @@ Every nori tool exposed in your tool list is a callable API. You can call any of
 |------|---------------|---------------|
 | nori_memory_search | hybrid phase start (retrieval gate) | ✅ Yes |
 | nori_memory_write | (none) | ✅ Yes |
+| nori_memory_edit | (none) | ✅ Yes |
 | nori_memory_remove | (none) | ✅ Yes |
 | nori_plan_write | (none) | ✅ Yes |
 | AgentSwarm | implementation delegation | ✅ Yes — preferred |
@@ -25,7 +26,8 @@ Every nori tool exposed in your tool list is a callable API. You can call any of
 ### Memory
 - **nori_memory_search** `{ keywords: string[], note_types?: string[], top_k?: number, include_linked?: boolean, link_depth?: number, chain_depth?: number, follow_up_keywords?: string[][] }` — Search Obsidian vault. Returns notes ranked by embedding+BM25+[[link graph]]. Use before making design decisions and call again whenever you discover better keywords. Keywords should be concrete: function names, error messages, concept labels. NOT generic terms. Use `chain_depth: 1` or `2` plus `follow_up_keywords` for chained memory retrieval.
 - **nori_memory_write** `{ note_type: "analysis"|"decision"|"task"|"review", title: string, content: string, tags?: string[], links?: string[] }` — Write to vault. Use [[wiki-links]] in content for bidirectional linking.
-- **nori_memory_remove** `{ title: string }` — Delete a note from the vault by exact title. Use sparingly; prefer nori_memory_write for corrections.
+- **nori_memory_edit** `{ title: string, content: string, tags?: string[], links?: string[] }` — Update an existing note in place by exact title. Does not create a new file. Omit `links` to keep current wiki-links; pass `["None"]` or `[]` to clear them.
+- **nori_memory_remove** `{ title: string }` — Delete a note from the vault by exact title. Use sparingly; prefer nori_memory_edit for corrections.
 - **nori_plan_write** `{ title: string, content: string }` — Write plan documents, design specs, and analysis files. In plan mode it writes the current session plan file; outside plan mode it writes project-local docs/plans/specs. NOT blocked by read-only mode. Use for writing plans, NOT for source code.
 
 ### Swarm

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -16,7 +16,8 @@ Available nori-specific tools:
 
 - **nori_memory_search** — Query the Obsidian shared memory vault (past analyses, ADR decisions, review records). Use keywords like function names, error messages, concept labels. It supports chained retrieval with `chain_depth` and `follow_up_keywords`; call it again when new keywords appear.
 - **nori_memory_write** — Write notes to the shared vault. `links: []` triggers auto-search first, `links: ["Title"]` links to specific notes, `links: ["None"]` skips linking. System auto-generates `## Related` with [[wiki-links]].
-- **nori_memory_remove** — Delete a note from the shared vault by exact title match. Use sparingly; prefer updating with nori_memory_write for corrections.
+- **nori_memory_edit** — Update an existing note in place by exact title. Omit `links` to keep current wiki-links; pass `["None"]` or `[]` to clear them.
+- **nori_memory_remove** — Delete a note from the shared vault by exact title match. Use sparingly; prefer nori_memory_edit for corrections.
 - **nori_plan_write** — Write plan documents, design specs, and analysis files. In plan mode it writes the current session plan file that `ExitPlanMode` reads; outside plan mode it writes project-local docs/plans/specs. NOT blocked by read-only mode. Use this for writing plans, NOT for source code.
 - **AgentSwarm** — Launch one or many sub-agents through the built-in swarm pipeline. Use `tasks` with `depends_on` for coding loops, and `prompt_template + items` for uniform parallel review.
 - **AgentSwarmControl** — List and inspect session swarms; stop, pause, add guidance while paused, or resume unfinished agents. Failed detached work is delivered as a system reminder and must be handled explicitly.

--- a/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
+++ b/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
@@ -64,7 +64,14 @@ export class ModelCatalogService
     for (const [modelId, alias] of Object.entries(config.models ?? {})) {
       const provider = config.providers[alias.provider];
       if (provider === undefined || provider.disabled) continue;
-      if (provider.customModels !== undefined && provider.customModels.length > 0 && !provider.customModels.includes(alias.model)) continue;
+      // Manual allow-lists only apply when automatic discovery is off.
+      // Leftover customModels must not hide aliases written by refresh.
+      if (
+        provider.autoDiscover === false
+        && provider.customModels !== undefined
+        && provider.customModels.length > 0
+        && !provider.customModels.includes(alias.model)
+      ) continue;
       models.push(toProtocolModel(modelId, alias, provider));
     }
     return models;

--- a/packages/agent-core/src/services/prompt/promptService.ts
+++ b/packages/agent-core/src/services/prompt/promptService.ts
@@ -118,6 +118,11 @@ function toPromptItem(state: PromptState, status: 'running' | 'queued'): PromptI
   };
 }
 
+function nonEmptyString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed;
+}
+
 function contentToCoreParts(content: PromptSubmission['content']): CorePromptPart[] {
   const input: CorePromptPart[] = [];
   for (const part of content) {
@@ -338,7 +343,9 @@ export class PromptService
     // Readiness gate. Throws AuthProvisioningRequired /
     // AuthTokenMissing / AuthModelNotResolved before we mint a prompt_id and
     // hand off to agent-core. Daemon route layer maps to 40110/40111/40113.
-    await this.auth.ensureReady();
+    // Prefer the prompt / session model over the global default so a
+    // configured conversation is not blocked by a missing default_model.
+    await this.auth.ensureReady(await this._modelForReadiness(sid, body.model));
 
     const promptId = `prompt_${ulid()}`;
     const state = this._createPromptState(sid, promptId, body);
@@ -365,7 +372,7 @@ export class PromptService
   async startBtw(sid: string): Promise<string> {
     await this._requireSession(sid);
     await this.core.rpc.resumeSession({ sessionId: sid });
-    await this.auth.ensureReady();
+    await this.auth.ensureReady(await this._modelForReadiness(sid));
     return this.core.rpc.startBtw({ sessionId: sid, agentId: MAIN_AGENT_ID });
   }
 
@@ -992,6 +999,26 @@ export class PromptService
     const matches = await this.core.rpc.listSessions({ sessionId: sid });
     if (matches.length === 0) {
       throw new SessionNotFoundError(sid);
+    }
+  }
+
+  /**
+   * Model id the auth gate should resolve: prompt override, then the
+   * already-bootstrapped session shadow, then the session profile.
+   * Falls through to `config.defaultModel` when this returns undefined.
+   */
+  private async _modelForReadiness(sid: string, bodyModel?: string): Promise<string | undefined> {
+    const fromBody = nonEmptyString(bodyModel);
+    if (fromBody !== undefined) return fromBody;
+
+    const fromShadow = nonEmptyString(this._agentState.get(sid)?.model);
+    if (fromShadow !== undefined) return fromShadow;
+
+    try {
+      const session = await this.sessionService.get(sid);
+      return nonEmptyString(session?.agent_config?.model);
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/agent-core/src/session/nori-providers.ts
+++ b/packages/agent-core/src/session/nori-providers.ts
@@ -42,6 +42,7 @@ interface MemoryNoteInfo {
   links: string[];
   mtimeMs: number;
   size: number;
+  writtenAt: string;
 }
 
 /* ------------------------------------------------------------------ */
@@ -56,7 +57,7 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
     }
   }
 
-  async multiRetrieve(keywords: string[], options?: MemoryRetrieveOptions): Promise<Array<{ title: string; path: string; score?: number; excerpt?: string; content?: string }>> {
+  async multiRetrieve(keywords: string[], options?: MemoryRetrieveOptions): Promise<Array<{ title: string; path: string; score?: number; excerpt?: string; content?: string; written_at?: string }>> {
     const topK = options?.top_k ?? 10;
     const notes = this.scoreNotes(keywords, options);
     return notes
@@ -66,6 +67,7 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
         score: note.fulltextScore > 0 ? note.fulltextScore : note.graphScore,
         excerpt: excerpt(note.body),
         content: note.body,
+        written_at: note.writtenAt,
       }))
       .filter((note) => note.score > 0)
       .toSorted((a, b) => b.score - a.score)
@@ -151,7 +153,7 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
           if (seenFiles.has(fp)) continue;
           seenFiles.add(fp);
           const raw = readFileSync(fp, 'utf-8');
-          const { title, body } = this.parseFrontmatter(raw);
+          const { title, body, fields } = this.parseFrontmatter(raw);
           const notePath = relative(this.vaultPath, fp).replaceAll('\\', '/');
           const wikiLinks: string[] = [];
           const linkRegex = /\[\[([^\]]+)\]\]/g;
@@ -182,6 +184,7 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
             links: wikiLinks,
             mtimeMs: stat.mtimeMs,
             size: stat.size,
+            writtenAt: resolveWrittenAt(fields, stat.mtimeMs),
           });
         }
       } catch { /* skip inaccessible dirs */ }
@@ -194,25 +197,63 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
   }): Promise<{ path: string }> {
     const dir = path.join(this.vaultPath, params.note_type);
     mkdirSync(dir, { recursive: true });
-    const dateStr = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const dateStr = now.toISOString().split('T')[0] ?? now.toISOString().slice(0, 10);
     const safeName = params.title
       .replaceAll(/[<>:"/\\|?*]/g, '-').replaceAll(/\s+/g, '-').toLowerCase().slice(0, 80);
     const fileName = dateStr + '-' + safeName + '.md';
     const fp = path.join(dir, fileName);
 
     const related = this.resolveRelatedLinks(params.links);
-    const fm = [
-      '---', `title: ${JSON.stringify(params.title)}`, `type: ${params.note_type}`,
-      'date: ' + dateStr,
-      ...(params.tags?.length ? ['tags:', ...params.tags.map(tag => `  - ${JSON.stringify(tag)}`)] : []),
-      ...(related.length > 0 ? ['related:', ...related.map(link => `  - ${JSON.stringify(link)}`)] : []),
-      '---',
-    ].filter(l => l.length > 0).join('\n');
+    const fm = buildMemoryFrontmatter({
+      title: params.title,
+      type: params.note_type,
+      date: dateStr,
+      writtenAt: now.toISOString(),
+      tags: params.tags,
+      related,
+    });
 
     const relatedSection = related.length > 0
       ? `\n\n## Related\n${related.map(link => `- ${link}`).join('\n')}`
       : '';
     writeFileSync(fp, `${fm}\n\n${params.content.trimEnd()}${relatedSection}\n`, 'utf-8');
+    return { path: relative(this.vaultPath, fp).replaceAll('\\', '/') };
+  }
+
+  async editNote(params: {
+    title: string; content: string; links?: string[]; tags?: string[];
+  }): Promise<{ path: string } | undefined> {
+    const fp = this.findNotePathByTitle(params.title);
+    if (fp === undefined) return undefined;
+    const raw = readFileSync(fp, 'utf-8');
+    const parsed = this.parseFrontmatter(raw);
+    const now = new Date();
+    const related = params.links === undefined
+      ? yamlStringList(parsed.fields['related'])
+      : this.resolveRelatedLinks(params.links);
+    const tags = params.tags ?? yamlStringList(parsed.fields['tags']);
+    const noteType = typeof parsed.fields['type'] === 'string' && parsed.fields['type'].trim() !== ''
+      ? parsed.fields['type'].trim()
+      : (relative(this.vaultPath, fp).replaceAll('\\', '/').split('/')[0] ?? 'analysis');
+    const fm = buildMemoryFrontmatter({
+      title: parsed.title,
+      type: noteType,
+      date: yamlDateOnly(parsed.fields['date'], now.toISOString().slice(0, 10)),
+      writtenAt: now.toISOString(),
+      tags,
+      related,
+    });
+    let body = params.content.trimEnd();
+    if (!/^## Related\b/m.test(body)) {
+      if (params.links === undefined) {
+        const previousRelated = extractRelatedSection(parsed.body);
+        if (previousRelated !== undefined) body = `${body}\n\n${previousRelated}`;
+      } else if (related.length > 0) {
+        body = `${body}\n\n## Related\n${related.map(link => `- ${link}`).join('\n')}`;
+      }
+    }
+    writeFileSync(fp, `${fm}\n\n${body}\n`, 'utf-8');
     return { path: relative(this.vaultPath, fp).replaceAll('\\', '/') };
   }
 
@@ -249,26 +290,29 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
   }
 
   async removeNote(title: string): Promise<boolean> {
-    const normalizedTitle = title.trim();
-    if (normalizedTitle.length === 0) return false;
+    const fp = this.findNotePathByTitle(title);
+    if (fp === undefined) return false;
     const trashDir = path.join(this.vaultPath, '.trash');
+    try {
+      mkdirSync(trashDir, { recursive: true });
+      renameSync(fp, this.availableTrashPath(trashDir, path.basename(fp)));
+    } catch {
+      return false;
+    }
+    return true;
+  }
+
+  private findNotePathByTitle(title: string): string | undefined {
+    const normalizedTitle = title.trim();
+    if (normalizedTitle.length === 0) return undefined;
     for (const fp of this.markdownFiles(this.vaultPath)) {
       try {
         const raw = readFileSync(fp, 'utf-8');
         const { title: noteTitle } = this.parseFrontmatter(raw);
-        if (noteTitle === normalizedTitle) {
-          try {
-            mkdirSync(trashDir, { recursive: true });
-            const dest = this.availableTrashPath(trashDir, path.basename(fp));
-            renameSync(fp, dest);
-          } catch {
-            return false;
-          }
-          return true;
-        }
+        if (noteTitle === normalizedTitle) return fp;
       } catch { /* skip unreadable files */ }
     }
-    return false;
+    return undefined;
   }
 
   private availableTrashPath(trashDir: string, fileName: string): string {
@@ -305,14 +349,23 @@ class SimpleMemoryProvider implements NoriMemoryProvider {
     return files;
   }
 
-  protected parseFrontmatter(content: string): { title: string; frontmatter: string; body: string } {
+  protected parseFrontmatter(content: string): {
+    title: string;
+    frontmatter: string;
+    body: string;
+    fields: Record<string, unknown>;
+  } {
     const normalized = content.replace(/^\uFEFF/, '').replaceAll('\r\n', '\n');
     const m = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-    if (!m) return { title: 'Untitled', frontmatter: '', body: normalized };
+    if (!m) return { title: 'Untitled', frontmatter: '', body: normalized, fields: {} };
     const frontmatter = m[1] ?? '';
     const body = m[2] ?? '';
+    const fields = parseYamlMapping(frontmatter);
     const tm = frontmatter.match(/^title:\s*['"]?(.+?)['"]?\s*$/m);
-    return { title: tm?.[1] ?? 'Untitled', frontmatter, body };
+    const title = typeof fields['title'] === 'string' && fields['title'].trim() !== ''
+      ? fields['title'].trim()
+      : tm?.[1] ?? 'Untitled';
+    return { title, frontmatter, body, fields };
   }
 }
 
@@ -332,7 +385,7 @@ class VectorMemoryProvider extends SimpleMemoryProvider {
   override async multiRetrieve(
     keywords: string[],
     options?: MemoryRetrieveOptions,
-  ): Promise<Array<{ title: string; path: string; score?: number; excerpt?: string; content?: string }>> {
+  ): Promise<Array<{ title: string; path: string; score?: number; excerpt?: string; content?: string; written_at?: string }>> {
     const endpoint = this.embeddingEndpoint();
     const apiKey = requiredConfig(this.config.apiKey, 'api_key');
     const model = requiredConfig(this.config.model, 'model');
@@ -398,6 +451,7 @@ class VectorMemoryProvider extends SimpleMemoryProvider {
           score,
           excerpt: excerpt(note.body),
           content: note.body,
+          written_at: note.writtenAt,
         };
       })
       .filter((note) => note.score > 0)
@@ -461,6 +515,77 @@ class VectorMemoryProvider extends SimpleMemoryProvider {
 
 function excerpt(body: string): string {
   return body.length > 500 ? `${body.slice(0, 500)}...` : body;
+}
+
+function parseYamlMapping(source: string): Record<string, unknown> {
+  if (source.trim() === '') return {};
+  try {
+    const parsed = loadYaml(source);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function resolveWrittenAt(fields: Record<string, unknown>, mtimeMs: number): string {
+  for (const key of ['written_at', 'updated', 'date'] as const) {
+    const iso = toIsoTimestamp(fields[key]);
+    if (iso !== undefined) return iso;
+  }
+  return new Date(mtimeMs).toISOString();
+}
+
+function toIsoTimestamp(value: unknown): string | undefined {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value < 1e12 ? value * 1000 : value;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Date.parse(value.trim());
+    if (!Number.isNaN(parsed)) return new Date(parsed).toISOString();
+  }
+  return undefined;
+}
+
+function yamlStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+}
+
+function yamlDateOnly(value: unknown, fallback: string): string {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString().slice(0, 10);
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim())) return value.trim().slice(0, 10);
+  return fallback;
+}
+
+function extractRelatedSection(body: string): string | undefined {
+  const match = /\n## Related\b[\s\S]*$/.exec(`\n${body}`);
+  const section = match?.[0]?.trim();
+  return section === undefined || section.length === 0 ? undefined : section;
+}
+
+function buildMemoryFrontmatter(params: {
+  title: string;
+  type: string;
+  date: string;
+  writtenAt: string;
+  tags?: string[];
+  related?: string[];
+}): string {
+  return [
+    '---',
+    `title: ${JSON.stringify(params.title)}`,
+    `type: ${params.type}`,
+    `date: ${params.date}`,
+    `written_at: ${JSON.stringify(params.writtenAt)}`,
+    ...(params.tags?.length ? ['tags:', ...params.tags.map(tag => `  - ${JSON.stringify(tag)}`)] : []),
+    ...(params.related?.length ? ['related:', ...params.related.map(link => `  - ${JSON.stringify(link)}`)] : []),
+    '---',
+  ].join('\n');
 }
 
 function requiredConfig<T>(value: T | undefined, name: string): T {

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -513,6 +513,7 @@ export class SessionSubagentHost {
     options: RunSubagentOptions,
   ): Promise<SubagentCompletion> {
     options.signal.throwIfAborted();
+    this.emitSubagentStarted(parent, childId);
     await this.triggerSubagentStart(parent, profileName, options.prompt, options.signal);
     options.signal.throwIfAborted();
 
@@ -524,8 +525,6 @@ export class SessionSubagentHost {
 
     const retrievedContext = await this.tryBuildNoriRetrievedContext(child, childPrompt, options.signal);
     if (retrievedContext !== undefined) childPrompt = `${retrievedContext}\n\n${childPrompt}`;
-
-    this.emitSubagentStarted(parent, childId);
     const turnId = child.turn.prompt([{ type: 'text', text: childPrompt }], SUBAGENT_PROMPT_ORIGIN);
     if (turnId === null) {
       throw new Error(`Agent instance "${childId}" could not start a turn`);
@@ -916,8 +915,11 @@ function renderNoriRetrievedContext(result: NoriMemoryChainResult): string {
       if (renderedPaths.has(note.path)) continue;
       renderedPaths.add(note.path);
       const score = note.score === undefined ? '' : ` score="${escapeXmlAttribute(note.score.toFixed(3))}"`;
+      const written = note.written_at === undefined
+        ? ''
+        : ` written_at="${escapeXmlAttribute(note.written_at)}"`;
       lines.push(
-        `<note path="${escapeXmlAttribute(note.path)}"${score}>`,
+        `<note path="${escapeXmlAttribute(note.path)}"${score}${written}>`,
         `<title>${escapeXmlText(note.title)}</title>`,
         `<content>${escapeXmlText(truncateForRetrievedContext(note.excerpt ?? note.content ?? ''))}</content>`,
         '</note>',

--- a/packages/agent-core/src/tools/builtin/nori/index.ts
+++ b/packages/agent-core/src/tools/builtin/nori/index.ts
@@ -1,5 +1,6 @@
 export * from './nori-memory-search';
 export * from './nori-memory-write';
+export * from './nori-memory-edit';
 export * from './nori-memory-remove';
 export * from './nori-plan-write';
 export * from './nori-ask-parent';

--- a/packages/agent-core/src/tools/builtin/nori/memory-chain.ts
+++ b/packages/agent-core/src/tools/builtin/nori/memory-chain.ts
@@ -132,8 +132,10 @@ export function formatNoriMemoryChainResult(result: NoriMemoryChainResult): stri
     }
     for (const note of hop.results) {
       const score = note.score === undefined ? 'N/A' : note.score.toFixed(2);
+      const written = note.written_at === undefined ? undefined : `written: ${note.written_at}`;
+      const meta = written === undefined ? `score: ${score}` : `score: ${score}, ${written}`;
       const body = truncateText(note.excerpt ?? note.content ?? '', 700);
-      lines.push(`- **${note.title}** (${note.path}) [score: ${score}]`);
+      lines.push(`- **${note.title}** (${note.path}) [${meta}]`);
       if (body.length > 0) lines.push(`  ${body}`);
     }
   }

--- a/packages/agent-core/src/tools/builtin/nori/nori-memory-edit.ts
+++ b/packages/agent-core/src/tools/builtin/nori/nori-memory-edit.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+import type { BuiltinTool } from '../../../agent/tool';
+import { ToolAccesses } from '../../../loop/tool-access';
+import type { ExecutableToolContext, ExecutableToolResult, ToolExecution } from '../../../loop/types';
+import { toInputJsonSchema } from '../../support/input-schema';
+import type { NoriMemoryProvider } from './types';
+
+const DESCRIPTION = `Edit an existing note in the Obsidian shared memory vault.
+
+Matches the note by exact title and updates that file in place. Does not create
+a new note — use nori_memory_write to add a note.
+
+Parameters:
+- title: exact title of the note to edit.
+- content: replacement markdown body. Do not manually write [[wiki-links]];
+  pass titles in links instead when you want to change related notes.
+- tags (optional): replace tags. Omit to keep the existing tags.
+- links (optional): replace related wiki-links. Omit to keep existing links.
+  Pass ["None"] or [] to clear links.`;
+
+const NoriMemoryEditInputSchema = z.object({
+  title: z.string().min(1).max(200),
+  content: z.string().min(1),
+  tags: z.array(z.string()).optional(),
+  links: z.array(z.string()).optional(),
+});
+
+type NoriMemoryEditInput = z.infer<typeof NoriMemoryEditInputSchema>;
+
+export class NoriMemoryEditTool implements BuiltinTool<NoriMemoryEditInput> {
+  readonly name = 'nori_memory_edit' as const;
+  readonly description: string = DESCRIPTION;
+  readonly parameters: Record<string, unknown> = toInputJsonSchema(NoriMemoryEditInputSchema);
+
+  constructor(private readonly memory: NoriMemoryProvider) {}
+
+  resolveExecution(args: NoriMemoryEditInput): ToolExecution {
+    return {
+      accesses: ToolAccesses.none(),
+      description: `Editing Obsidian note: ${args.title}`,
+      approvalRule: this.name,
+      execute: (ctx) => this.execution(args, ctx),
+    };
+  }
+
+  private async execution(
+    args: NoriMemoryEditInput,
+    _context: ExecutableToolContext,
+  ): Promise<ExecutableToolResult> {
+    try {
+      const isExplicitNone = args.links?.length === 1 && args.links[0] === 'None';
+      const links = args.links === undefined
+        ? undefined
+        : isExplicitNone || args.links.length === 0
+          ? []
+          : args.links;
+      const relatedSection = links === undefined
+        ? undefined
+        : links.length === 0
+          ? '_None_'
+          : links.map(l => `- [[${l}]]`).join('\n');
+      const fullContent = relatedSection === undefined
+        ? args.content
+        : `${args.content}\n\n## Related\n\n${relatedSection}`;
+
+      const result = await this.memory.editNote({
+        title: args.title,
+        content: fullContent,
+        tags: args.tags,
+        links,
+      });
+      if (result === undefined) {
+        return { output: `Note not found: "${args.title}". No matching note with that exact title.` };
+      }
+      return { output: `Note edited: ${result.path}` };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { output: `Memory edit failed: ${message}`, isError: true };
+    }
+  }
+}

--- a/packages/agent-core/src/tools/builtin/nori/nori-memory-remove.ts
+++ b/packages/agent-core/src/tools/builtin/nori/nori-memory-remove.ts
@@ -12,7 +12,7 @@ Matches the note by exact title. If a note with the given title exists, it is
 permanently deleted. Returns whether the note was found and removed.
 
 Use this sparingly — only for notes that are genuinely obsolete or incorrect.
-Prefer nori_memory_write with updated content for corrections.`;
+Prefer nori_memory_edit to correct an existing note in place.`;
 
 const NoriMemoryRemoveInputSchema = z.object({
   title: z.string().min(1).max(200),

--- a/packages/agent-core/src/tools/builtin/nori/types.ts
+++ b/packages/agent-core/src/tools/builtin/nori/types.ts
@@ -6,6 +6,7 @@ export interface NoriMemoryNote {
   score?: number;
   excerpt?: string;
   content?: string;
+  written_at?: string;
 }
 
 export interface NoriMemoryProvider {
@@ -25,6 +26,12 @@ export interface NoriMemoryProvider {
     links?: string[];
     tags?: string[];
   }): Promise<{ path: string }>;
+  editNote(params: {
+    title: string;
+    content: string;
+    links?: string[];
+    tags?: string[];
+  }): Promise<{ path: string } | undefined>;
   removeNote(title: string): Promise<boolean>;
 }
 

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -187,6 +187,7 @@ describe('Agent turn flow', () => {
         },
       ]),
       writeNote: vi.fn(),
+      editNote: vi.fn(),
       removeNote: vi.fn(async () => false),
     };
     const ctx = testAgent();

--- a/packages/agent-core/test/services/model-catalog-service.test.ts
+++ b/packages/agent-core/test/services/model-catalog-service.test.ts
@@ -206,6 +206,73 @@ describe('ModelCatalogService', () => {
     expect(getCalls).toEqual([{ reload: true }, { reload: true }]);
   });
 
+  it('does not hide auto-discovered aliases behind leftover customModels', async () => {
+    const configRef: { current: KimiConfig } = {
+      current: {
+        providers: {
+          gateway: {
+            type: 'openai',
+            apiKey: 'sk-test',
+            autoDiscover: true,
+            customModels: ['manual-only'],
+          },
+        },
+        models: {
+          'gateway/chat': {
+            provider: 'gateway',
+            model: 'chat',
+            maxContextSize: 128000,
+          },
+          'gateway/manual-only': {
+            provider: 'gateway',
+            model: 'manual-only',
+            maxContextSize: 128000,
+          },
+        },
+      },
+    };
+    const { core } = makeCore(configRef);
+    const svc = new ModelCatalogService(makeEnv(), core, makeEventService().svc);
+
+    await expect(svc.listModels()).resolves.toEqual([
+      expect.objectContaining({ model: 'gateway/chat' }),
+      expect.objectContaining({ model: 'gateway/manual-only' }),
+    ]);
+  });
+
+  it('filters aliases by customModels only when auto-discovery is disabled', async () => {
+    const configRef: { current: KimiConfig } = {
+      current: {
+        providers: {
+          gateway: {
+            type: 'openai',
+            apiKey: 'sk-test',
+            autoDiscover: false,
+            customModels: ['manual-only'],
+          },
+        },
+        models: {
+          'gateway/chat': {
+            provider: 'gateway',
+            model: 'chat',
+            maxContextSize: 128000,
+          },
+          'gateway/manual-only': {
+            provider: 'gateway',
+            model: 'manual-only',
+            maxContextSize: 128000,
+          },
+        },
+      },
+    };
+    const { core } = makeCore(configRef);
+    const svc = new ModelCatalogService(makeEnv(), core, makeEventService().svc);
+
+    await expect(svc.listModels()).resolves.toEqual([
+      expect.objectContaining({ model: 'gateway/manual-only' }),
+    ]);
+  });
+
   it('advertises official Kimi Coding endpoint input capabilities for stale aliases', async () => {
     const configRef: { current: KimiConfig } = {
       current: {

--- a/packages/agent-core/test/services/prompt-service.test.ts
+++ b/packages/agent-core/test/services/prompt-service.test.ts
@@ -360,6 +360,39 @@ describe('PromptService.submit', () => {
     expect(result.user_message_id).toMatch(/^msg_sess_01PT_pending_prompt_/);
   });
 
+  it('passes the prompt model to ensureReady', async () => {
+    const { bridge } = makeBridge();
+    const { bus } = makeBus();
+    const auth = makeAuth();
+    const impl = newSvc(bridge, bus, auth);
+    await impl.submit(SID, mkBody({ model: 'openai/gpt-4o' }));
+    expect(auth.ensureReady).toHaveBeenCalledWith('openai/gpt-4o');
+  });
+
+  it('passes the session shadow model to ensureReady when the body has none', async () => {
+    const { bridge } = makeBridge({ config: { modelAlias: 'kimi-code/k2' } });
+    const { bus } = makeBus();
+    const auth = makeAuth();
+    const impl = newSvc(bridge, bus, auth);
+    await impl.applyAgentState(SID, { model: 'kimi-code/k9' }, 'meta');
+    await impl.submit(SID, mkBodyMinimal());
+    expect(auth.ensureReady).toHaveBeenCalledWith('kimi-code/k9');
+  });
+
+  it('passes the session profile model to ensureReady when shadow is empty', async () => {
+    const { bridge } = makeBridge();
+    const { bus } = makeBus();
+    const auth = makeAuth();
+    const { sessionService } = makeSessionService();
+    sessionService.get = vi.fn().mockResolvedValue({
+      id: SID,
+      agent_config: { model: 'provider/chat' },
+    } as Session);
+    const impl = newSvc(bridge, bus, auth, sessionService);
+    await impl.submit(SID, mkBodyMinimal());
+    expect(auth.ensureReady).toHaveBeenCalledWith('provider/chat');
+  });
+
   it('translates text + image content to kosong ContentParts', async () => {
     const { bridge, record } = makeBridge();
     const { bus } = makeBus();

--- a/packages/agent-core/test/session/nori-providers.test.ts
+++ b/packages/agent-core/test/session/nori-providers.test.ts
@@ -55,6 +55,60 @@ describe('Nori filesystem memory provider', () => {
     expect(content).toContain('## Related\n- [[decision/architecture|Architecture choice]]');
   });
 
+  it('records ISO written_at on write and returns it from search', async () => {
+    const root = await tempRoot();
+    const providers = createNoriProvidersFromConfig(
+      { obsidian: { vault_path: './nori-vault' } },
+      SIMPLE_CONFIG,
+      root,
+    );
+    if (providers === null) throw new Error('expected providers');
+
+    const written = await providers.memory.writeNote({
+      note_type: 'analysis',
+      title: 'Write timestamp note',
+      content: 'Remember the write time.',
+    });
+    const content = await readFile(join(root, 'nori-vault', written.path), 'utf-8');
+    const writtenAt = content.match(/^written_at:\s*"([^"]+)"$/m)?.[1];
+    expect(writtenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const results = await providers.memory.multiRetrieve(['Write timestamp note']);
+    expect(results[0]?.written_at).toBe(writtenAt);
+  });
+
+  it('edits an existing note in place without creating a new file', async () => {
+    const root = await tempRoot();
+    const vault = join(root, 'nori-vault');
+    const providers = createNoriProvidersFromConfig(
+      { obsidian: { vault_path: './nori-vault' } },
+      SIMPLE_CONFIG,
+      root,
+    );
+    if (providers === null) throw new Error('expected providers');
+
+    const written = await providers.memory.writeNote({
+      note_type: 'analysis',
+      title: 'Editable note',
+      content: 'Original body.',
+      tags: ['keep'],
+    });
+    const edited = await providers.memory.editNote({
+      title: 'Editable note',
+      content: 'Replacement body.',
+    });
+    expect(edited?.path).toBe(written.path);
+    const content = await readFile(join(vault, written.path), 'utf-8');
+    expect(content).toContain('Replacement body.');
+    expect(content).not.toContain('Original body.');
+    expect(content).toContain('title: "Editable note"');
+    expect(content).toContain('- "keep"');
+    expect(await providers.memory.editNote({
+      title: 'Missing note',
+      content: 'nope',
+    })).toBeUndefined();
+  });
+
   it('does not make embedding requests in simple mode', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -991,6 +991,7 @@ describe('SessionSubagentHost', () => {
         },
       ]),
       writeNote: vi.fn(async () => ({ path: 'analysis/unused.md' })),
+      editNote: vi.fn(async () => ({ path: 'analysis/unused.md' })),
       removeNote: vi.fn(async () => false),
     };
     const summary =

--- a/packages/agent-core/test/tools/builtin-current.test.ts
+++ b/packages/agent-core/test/tools/builtin-current.test.ts
@@ -53,6 +53,7 @@ import {
   NoriMemorySearchInputSchema,
   NoriMemorySearchTool,
 } from '../../src/tools/builtin/nori/nori-memory-search';
+import { NoriMemoryEditTool } from '../../src/tools/builtin/nori/nori-memory-edit';
 import { NoriPlanWriteTool } from '../../src/tools/builtin/nori/nori-plan-write';
 import type { NoriMemoryProvider } from '../../src/tools/builtin/nori/types';
 
@@ -1252,6 +1253,7 @@ describe('current builtin collaboration tools', () => {
         return [];
       }),
       writeNote: vi.fn(),
+      editNote: vi.fn(),
       removeNote: vi.fn(async () => false),
     };
     const tool = new NoriMemorySearchTool(memory);
@@ -1282,6 +1284,49 @@ describe('current builtin collaboration tools', () => {
     expect(result.output).toContain('Found 2 unique note(s)');
     expect(result.output).toContain('## Hop 1');
     expect(result.output).toContain('Permission Rules');
+  });
+
+  it('nori_memory_edit updates a note in place by exact title', async () => {
+    const memory: NoriMemoryProvider = {
+      multiRetrieve: vi.fn(async () => []),
+      writeNote: vi.fn(),
+      editNote: vi.fn(async () => ({ path: 'analysis/architecture.md' })),
+      removeNote: vi.fn(async () => false),
+    };
+    const tool = new NoriMemoryEditTool(memory);
+    const result = await executeTool(
+      tool,
+      context({
+        title: 'Architecture choice',
+        content: 'Updated body',
+        links: ['None'],
+      }),
+    );
+
+    expect(memory.editNote).toHaveBeenCalledWith({
+      title: 'Architecture choice',
+      content: 'Updated body\n\n## Related\n\n_None_',
+      tags: undefined,
+      links: [],
+    });
+    expect(result.output).toContain('Note edited: analysis/architecture.md');
+  });
+
+  it('nori_memory_edit reports a missing note without creating one', async () => {
+    const memory: NoriMemoryProvider = {
+      multiRetrieve: vi.fn(async () => []),
+      writeNote: vi.fn(),
+      editNote: vi.fn(async () => undefined),
+      removeNote: vi.fn(async () => false),
+    };
+    const tool = new NoriMemoryEditTool(memory);
+    const result = await executeTool(
+      tool,
+      context({ title: 'Missing', content: 'body' }),
+    );
+
+    expect(result.output).toContain('Note not found: "Missing"');
+    expect(memory.writeNote).not.toHaveBeenCalled();
   });
 
   it('nori_plan_write writes to the active session plan file during plan mode', async () => {

--- a/packages/oauth/src/refresh-provider-models.ts
+++ b/packages/oauth/src/refresh-provider-models.ts
@@ -407,11 +407,13 @@ export async function refreshProviderModels(
       const added = [...nextIds].filter((id) => !oldIds.has(id)).length;
       const removed = [...oldIds].filter((id) => !nextIds.has(id)).length;
       const firstDiscovered = discovered[0];
-      const nextDefault = config.defaultModel && nextModels[config.defaultModel]
-        ? config.defaultModel
-        : (config.defaultModel?.startsWith(providerId + '/') && firstDiscovered !== undefined
-          ? providerId + '/' + firstDiscovered.id
-          : config.defaultModel);
+      const firstAlias = firstDiscovered === undefined ? undefined : providerId + '/' + firstDiscovered.id;
+      const existingDefault = config.defaultModel;
+      const nextDefault = existingDefault && nextModels[existingDefault]
+        ? existingDefault
+        : (existingDefault?.startsWith(providerId + '/') && firstAlias !== undefined
+          ? firstAlias
+          : (existingDefault ?? firstAlias));
 
       await host.removeProvider(providerId);
       config = await host.setConfig({

--- a/packages/oauth/test/refresh-provider-models.test.ts
+++ b/packages/oauth/test/refresh-provider-models.test.ts
@@ -107,6 +107,55 @@ describe('refreshProviderModels', () => {
     expect(harness.config().defaultModel).toBe('custom/gpt-new');
   });
 
+  it('sets defaultModel to the first discovered alias when none is configured', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: [{ id: 'gpt-new' }, { id: 'gpt-other' }] })));
+    const harness = makeHost({
+      providers: {
+        custom: {
+          type: 'openai',
+          baseUrl: 'https://gateway.example/v1',
+          apiKey: 'secret',
+        },
+      },
+      models: {},
+    });
+
+    const result = await refreshProviderModels(harness.host, { providerId: 'custom' });
+
+    expect(result.failed).toEqual([]);
+    expect(harness.config().defaultModel).toBe('custom/gpt-new');
+  });
+
+  it('keeps an unrelated defaultModel when discovering another provider', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: [{ id: 'gpt-new' }] })));
+    const harness = makeHost({
+      providers: {
+        custom: {
+          type: 'openai',
+          baseUrl: 'https://gateway.example/v1',
+          apiKey: 'secret',
+        },
+        other: {
+          type: 'openai',
+          baseUrl: 'https://other.example/v1',
+          apiKey: 'secret',
+        },
+      },
+      models: {
+        'other/keep-me': {
+          provider: 'other',
+          model: 'keep-me',
+          maxContextSize: 8192,
+        },
+      },
+      defaultModel: 'other/keep-me',
+    });
+
+    await refreshProviderModels(harness.host, { providerId: 'custom' });
+
+    expect(harness.config().defaultModel).toBe('other/keep-me');
+  });
+
   it('infers OpenCode-compatible GPT-5 efforts when a manual provider only returns model IDs', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: [{ id: 'gpt-5.4' }] })));
     const harness = makeHost({

--- a/packages/server/src/routes/swarmStatus.ts
+++ b/packages/server/src/routes/swarmStatus.ts
@@ -173,7 +173,7 @@ export function synchronizeSwarmTasks(
       return task.status === 'running' ? { ...task, status: 'paused' } : task;
     }
     if (status === 'running') {
-      return task.status === 'paused' ? { ...task, status: 'pending' } : task;
+      return task.status === 'paused' ? { ...task, status: 'running' } : task;
     }
     if (status === 'done') return { ...task, status: 'completed' };
     if (status === 'stopped') return { ...task, status: 'cancelled' };
@@ -257,6 +257,18 @@ export function findSwarmByToolCall(
     && entry.owner_agent_id === ownerAgentId
     && entry.tool_call_id === toolCallId,
   );
+}
+
+export function findActiveSwarmByOwner(
+  sessionId: string,
+  ownerAgentId: string,
+): SwarmStatusEntry | undefined {
+  const matches = [...swarmState.values()].filter(entry =>
+    entry.session_id === sessionId
+    && entry.owner_agent_id === ownerAgentId
+    && (entry.status === 'running' || entry.status === 'pending' || entry.status === 'paused'),
+  );
+  return matches.at(-1);
 }
 
 export function findSwarmByAgent(sessionId: string, agentId: string): SwarmStatusEntry | undefined {

--- a/packages/server/src/routes/vault.ts
+++ b/packages/server/src/routes/vault.ts
@@ -3,8 +3,8 @@
  * Reads markdown files directly from the filesystem.
  */
 
-import { readFileSync, readdirSync, existsSync, statSync, type Dirent } from 'node:fs';
-import { join, basename, relative } from 'node:path';
+import { readFileSync, readdirSync, existsSync, statSync, writeFileSync, type Dirent } from 'node:fs';
+import { join, basename, relative, resolve } from 'node:path';
 import { z } from 'zod';
 import { parse as parseYaml } from 'yaml';
 import { okEnvelope } from '../envelope';
@@ -17,6 +17,14 @@ interface RouteHost {
     options: { schema?: Record<string, unknown> },
     handler: (
       req: { id: string; query: Record<string, unknown>; params: Record<string, unknown> },
+      reply: { send(payload: unknown): void },
+    ) => Promise<void> | void,
+  ): unknown;
+  post(
+    path: string,
+    options: { schema?: Record<string, unknown> },
+    handler: (
+      req: { id: string; params: Record<string, unknown>; body: { content: string } },
       reply: { send(payload: unknown): void },
     ) => Promise<void> | void,
   ): unknown;
@@ -50,6 +58,10 @@ const listQuerySchema = z.object({
 const noteIdParamsSchema = z.object({
   note_id: z.string(),
 });
+
+const updateNoteBodySchema = z.object({
+  content: z.string().min(1),
+}).strict();
 
 export type NoteEntry = z.infer<typeof noteSchema>;
 
@@ -93,10 +105,10 @@ export function scanVault(vaultPath: string): NoteEntry[] {
       let content: string;
       try { content = readFileSync(filePath, 'utf-8'); } catch { continue; }
 
-      // Get file modification time
+      // Prefer frontmatter write time, then file mtime as a full ISO timestamp.
       let mtime = '';
       try {
-        mtime = statSync(filePath).mtime.toISOString().slice(0, 10);
+        mtime = statSync(filePath).mtime.toISOString();
       } catch { mtime = ''; }
 
       const frontmatter = parseFrontmatter(content);
@@ -135,7 +147,7 @@ export function scanVault(vaultPath: string): NoteEntry[] {
         type: noteType,
         folder: noteType,
         preview,
-        date: mtime,
+        date: noteTimestamp(frontmatter, mtime),
         path: notePath,
         links,
       });
@@ -216,6 +228,44 @@ function findNote(notes: NoteEntry[], noteId: string): NoteEntry | null {
   }) ?? null;
 }
 
+function noteTimestamp(frontmatter: Record<string, unknown>, mtimeIso: string): string {
+  for (const key of ['written_at', 'updated', 'date'] as const) {
+    const iso = toIsoTimestamp(frontmatter[key]);
+    if (iso !== undefined) return iso;
+  }
+  return mtimeIso;
+}
+
+function toIsoTimestamp(value: unknown): string | undefined {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Date.parse(value.trim());
+    if (!Number.isNaN(parsed)) return new Date(parsed).toISOString();
+  }
+  return undefined;
+}
+
+function resolveVaultFile(vaultPath: string, notePath: string): string | undefined {
+  const root = resolve(vaultPath);
+  const target = resolve(root, notePath);
+  const rel = relative(root, target);
+  if (rel === '' || rel.startsWith('..')) return undefined;
+  return target;
+}
+
+function stampWrittenAt(content: string, writtenAt: string): string {
+  const normalized = content.replaceAll('\r\n', '\n');
+  const match = /^---\n([\s\S]*?)\n---(\n[\s\S]*)?$/.exec(normalized);
+  if (!match) return content;
+  const frontmatter = match[1] ?? '';
+  const body = match[2] ?? '\n';
+  const line = `written_at: ${JSON.stringify(writtenAt)}`;
+  const nextFrontmatter = /^written_at:\s*.+$/m.test(frontmatter)
+    ? frontmatter.replace(/^written_at:\s*.+$/m, line)
+    : `${frontmatter}\n${line}`;
+  return `---\n${nextFrontmatter}\n---${body.startsWith('\n') ? body : `\n${body}`}`;
+}
+
 export function registerVaultRoutes(app: RouteHost, _ix: IInstantiationService): void {
   const vaultPath = resolveVaultPath();
 
@@ -284,4 +334,36 @@ export function registerVaultRoutes(app: RouteHost, _ix: IInstantiationService):
     },
   );
   app.get(noteRoute.path, noteRoute.options, noteRoute.handler as Parameters<RouteHost['get']>[2]);
+
+  const updateRoute = defineRoute(
+    {
+      method: 'POST',
+      path: '/vault/notes/{note_id}',
+      params: noteIdParamsSchema,
+      body: updateNoteBodySchema,
+      success: { data: noteDetailSchema.nullable() },
+      description: 'Update a vault note by encoded title or path',
+      tags: ['vault'],
+    },
+    async (req, reply) => {
+      const noteId = req.params['note_id'];
+      const note = findNote(scanVault(vaultPath), noteId);
+      if (!note) {
+        reply.send(okEnvelope(null, req.id));
+        return;
+      }
+      const target = resolveVaultFile(vaultPath, note.path);
+      if (target === undefined) {
+        reply.send(okEnvelope(null, req.id));
+        return;
+      }
+      const stamped = stampWrittenAt(req.body.content, new Date().toISOString());
+      writeFileSync(target, stamped, 'utf-8');
+      const updated = findNote(scanVault(vaultPath), note.path);
+      let content = stamped;
+      try { content = readFileSync(target, 'utf-8'); } catch { /* keep stamped content */ }
+      reply.send(okEnvelope(updated ? { ...updated, content } : { ...note, content }, req.id));
+    },
+  );
+  app.post(updateRoute.path, updateRoute.options, updateRoute.handler as Parameters<RouteHost['post']>[2]);
 }

--- a/packages/server/src/services/gateway/wsBroadcastService.ts
+++ b/packages/server/src/services/gateway/wsBroadcastService.ts
@@ -19,6 +19,7 @@ import { buildEventEnvelope, type EventEnvelope } from '#/ws/protocol';
 import {
   countSettledSwarmTasks,
   findSwarmByAgent,
+  findActiveSwarmByOwner,
   findSwarmByToolCall,
   getSwarmStatus,
   nextSwarmRound,
@@ -256,7 +257,8 @@ export class WSBroadcastService extends Disposable implements IWSBroadcastServic
 
     if (event.type === 'subagent.spawned') {
       const ownerAgentId = event.parentAgentId ?? event.agentId;
-      const swarm = findSwarmByToolCall(sid, ownerAgentId, event.parentToolCallId);
+      const swarm = findSwarmByToolCall(sid, ownerAgentId, event.parentToolCallId)
+        ?? findActiveSwarmByOwner(sid, ownerAgentId);
       if (swarm === undefined) return;
       const task: SwarmTaskStatusEntry = {
         id: event.subagentId,
@@ -264,7 +266,7 @@ export class WSBroadcastService extends Disposable implements IWSBroadcastServic
         parent_agent_id: ownerAgentId,
         profile: event.subagentName,
         label: event.description ?? `Agent ${String((event.swarmIndex ?? 0) + 1)}`,
-        status: 'pending',
+        status: 'running',
       };
       updateSwarmStatus(swarm.swarm_id, current => {
         const tasks = upsertSwarmTask(current.tasks, task);

--- a/packages/server/test/auth.e2e.test.ts
+++ b/packages/server/test/auth.e2e.test.ts
@@ -6,8 +6,12 @@
  *                                    submit blocked with `40110`.
  *   2. **Manual provider, no key** → ready=false (key gate not met);
  *                                    prompt submit blocked with `40111`.
- *   3. **Provider, no default**    → ready=false (no default_model);
+ *   3. **Provider, no default, no prompt/session model**
+ *                                    → GET ready=false (no default_model);
  *                                    prompt submit blocked with `40113`.
+ *   3b. **Provider, no default, prompt or session model set**
+ *                                    → GET still ready=false; prompt submit
+ *                                    passes the gate using that model.
  *   4. **Provider + key + model**  → ready=true; prompt submit gets past the
  *                                    gate (and may fail downstream — that's
  *                                    out of scope here).
@@ -309,7 +313,6 @@ describe('POST /api/v1/sessions/{sid}/prompts — readiness gate (P2.1 D1)', () 
       url: `/api/v1/sessions/${sid}/prompts`,
       payload: {
         content: [{ type: 'text', text: 'hello' }],
-        model: 'x',
         thinking: 'off',
         permission_mode: 'manual',
         plan_mode: false,
@@ -342,7 +345,6 @@ describe('POST /api/v1/sessions/{sid}/prompts — readiness gate (P2.1 D1)', () 
       url: `/api/v1/sessions/${sid}/prompts`,
       payload: {
         content: [{ type: 'text', text: 'hello' }],
-        model: 'x',
         thinking: 'off',
         permission_mode: 'manual',
         plan_mode: false,
@@ -353,6 +355,73 @@ describe('POST /api/v1/sessions/{sid}/prompts — readiness gate (P2.1 D1)', () 
     // No model_id in details when default is simply unset — clients should
     // route to "select a model" UX rather than "this alias is broken".
     expect(env.details).toBeNull();
+  });
+
+  it('passes the readiness gate when the prompt model resolves without default_model', async () => {
+    seedConfig(
+      [
+        '[providers.x]',
+        'type = "kimi"',
+        'api_key = "sk-test"',
+        '',
+        '[models.x]',
+        'provider = "x"',
+        'model = "x"',
+        'max_context_size = 1000',
+        '',
+      ].join('\n'),
+    );
+    const r = await bootDaemon();
+    const sid = await createSession(r);
+    const res = await appOf(r).inject({
+      method: 'POST',
+      url: `/api/v1/sessions/${sid}/prompts`,
+      payload: {
+        content: [{ type: 'text', text: 'hello' }],
+        model: 'x',
+        thinking: 'off',
+        permission_mode: 'manual',
+        plan_mode: false,
+      },
+    });
+    const env = envelopeOf<unknown>(res.json());
+    expect([40110, 40111, 40112, 40113]).not.toContain(env.code);
+  });
+
+  it('passes the readiness gate when the session model is set without default_model', async () => {
+    seedConfig(
+      [
+        '[providers.x]',
+        'type = "kimi"',
+        'api_key = "sk-test"',
+        '',
+        '[models.x]',
+        'provider = "x"',
+        'model = "x"',
+        'max_context_size = 1000',
+        '',
+      ].join('\n'),
+    );
+    const r = await bootDaemon();
+    const sid = await createSession(r);
+    const profile = await appOf(r).inject({
+      method: 'POST',
+      url: `/api/v1/sessions/${sid}/profile`,
+      payload: { agent_config: { model: 'x' } },
+    });
+    expect(envelopeOf(profile.json()).code).toBe(0);
+    const res = await appOf(r).inject({
+      method: 'POST',
+      url: `/api/v1/sessions/${sid}/prompts`,
+      payload: {
+        content: [{ type: 'text', text: 'hello' }],
+        thinking: 'off',
+        permission_mode: 'manual',
+        plan_mode: false,
+      },
+    });
+    const env = envelopeOf<unknown>(res.json());
+    expect([40110, 40111, 40112, 40113]).not.toContain(env.code);
   });
 
   it('passes the readiness gate when provider + key + default_model are all set', async () => {

--- a/packages/server/test/services.test.ts
+++ b/packages/server/test/services.test.ts
@@ -630,7 +630,9 @@ describe('WSBroadcastService (WS transport pump)', () => {
       swarmIndex: 0,
       runInBackground: true,
     } as unknown as Event);
-    expect(getSwarmStatus(swarmId)?.tasks).toHaveLength(1);
+    expect(getSwarmStatus(swarmId)?.tasks).toEqual([
+      expect.objectContaining({ status: 'running' }),
+    ]);
     bus.publish({
       type: 'subagent.started',
       sessionId,
@@ -774,7 +776,7 @@ describe('WSBroadcastService (WS transport pump)', () => {
     } as unknown as Event);
     expect(getSwarmStatus(swarmId)).toMatchObject({
       status: 'running',
-      tasks: [{ status: 'pending' }, { status: 'pending' }],
+      tasks: [{ status: 'running' }, { status: 'running' }],
     });
 
     bus.publish({ type: 'subagent.started', sessionId, agentId: 'main', subagentId: 'agent-control-1' } as unknown as Event);

--- a/packages/server/test/vault.test.ts
+++ b/packages/server/test/vault.test.ts
@@ -40,6 +40,29 @@ describe('vault note scanning', () => {
     ]);
   });
 
+  it('prefers frontmatter written_at as a full ISO timestamp', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'nori-vault-'));
+    tempDirs.push(vault);
+    await mkdir(join(vault, 'analysis'), { recursive: true });
+    await writeFile(join(vault, 'analysis', 'timed.md'), [
+      '---',
+      'title: Timed note',
+      'type: analysis',
+      'date: 2026-01-02',
+      'written_at: "2026-08-17T01:02:03.000Z"',
+      '---',
+      '',
+      'Body.',
+    ].join('\n'), 'utf8');
+
+    expect(scanVault(vault)).toEqual([
+      expect.objectContaining({
+        title: 'Timed note',
+        date: '2026-08-17T01:02:03.000Z',
+      }),
+    ]);
+  });
+
   it('reads notes from the legacy analyses folder without changing their canonical type', async () => {
     const vault = await mkdtemp(join(tmpdir(), 'nori-vault-'));
     tempDirs.push(vault);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issue

No linked issue. This PR continues the web/runtime work on the same branch.

## Problem

1. Swarm activity badges could attach to the wrong session, and the collaboration page showed every agent as waiting even when work was running.
2. Memory search did not show when a note was written, and there was no way to edit an existing vault note from the agent.
3. Expanding a tool call in the web transcript truncated details or showed Edit placeholders instead of the real diff.
4. Adding a provider with automatic model discovery could leave no global default. Sending a message then failed with “no default model configured” even when the conversation already had a model selected. An empty session model string also hid a configured draft/runtime model in the composer.

## What changed

- Spawned swarm agents start as `running` instead of staying `pending`; resume restores `running`; the activity badge uses the current session’s subagents.
- Added `nori_memory_edit` and a vault note update API. Memory search results include a `written` timestamp.
- Web tool calls expand to the full input/output. Edit summaries use the recorded diff (`+added -removed`) and drop `[original line N replaced]` placeholders.
- Prompt submit now resolves the prompt or session model before the auth gate, so a configured conversation is not blocked by a missing global default.
- Auto-discovery writes a default model when none is set, leftover custom-model allow-lists no longer hide discovered aliases, and the web composer treats an empty session model as unset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eae8a43c-2b53-44f6-81c9-e3a6c9517320?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eae8a43c-2b53-44f6-81c9-e3a6c9517320&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

